### PR TITLE
Debian 8 requires bc for xfstests

### DIFF
--- a/scripts/bb-dependencies.sh
+++ b/scripts/bb-dependencies.sh
@@ -46,7 +46,7 @@ Debian*)
 
     # Required utilties.
     sudo apt-get --yes install git alien fakeroot wget curl \
-        lsscsi parted gdebi attr dbench watchdog
+        lsscsi parted gdebi attr dbench watchdog bc
 
     # Required development libraries
     sudo apt-get --yes install linux-headers-$(uname -r) \


### PR DESCRIPTION
Debian 8 (Jessie) packages math program bc in a package called bc.  Add it to
the dependencies.

xfstests-zfs requires bc.  See zfs-buildbot issue https://github.com/zfsonlinux/zfs-buildbot/issues/8

Signed-off-by: Olaf Faaland <faaland1@llnl.gov>