### PR TITLE
Price multiplier was not being set correctly in mkEC2UserDataSlave.

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -91,7 +91,7 @@ runurl """ + bb_url + """bb-bootstrap.sh
         if key=="max_spot_price":
             max_spot_price=kwargs[key]
         if key=="price_multiplier":
-            max_spot_price=kwargs[key]
+            price_multiplier=kwargs[key]
         if key=="placement":
             placement=kwargs[key]
 


### PR DESCRIPTION
Price multiplier was not being set correctly in mkEC2UserDataSlave. Now correctly assigning price multiplier if it is provided by the caller.

Signed-off-by: Giuseppe Di Natale <dinatale2@llnl.gov>