### PR TITLE
Improved how builders are prioritized when assigned changes.

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -293,25 +293,45 @@ builder_linux_builtin_properties = {
 def prioritizeBuilders(buildmaster, builders):
     """
     Called by the buildmaster to prioritize the builders.  Returns a sorted
-    array of builders designed to improve ec2 utilization of substantiated but
-    idle buildslaves.  Builders with pending builds and idle buildslaves are
-    given priority.  This helps keep all buildslaves busy while new latent
-    buildslaves are bootstrapped, a process which can take several minutes.
+    array of builders designed to improve ec2 utilization. Builders with
+    substantiated, idle slaves are given priority. Followed by builders with no
+    substantiated slaves. The lowest priority is a builder that is busy.
+    This helps keep all buildslaves busy while new latent buildslaves are 
+    bootstrapped, a process which can take several minutes.
     """
 
-    sorted_builders = []
+    idle_builders = []
+    busy_builders = []
+    avail_builders = []
+
     for b in builders:
         idle = False
+        busy = False
         for s in b.slaves:
             if s.isIdle():
                idle = True
                break
 
-        # Prioritize BUILD over TEST builders.
-        if idle is True and re.search('BUILD', b.name):
-            sorted_builders.insert(0, b)
+            if s.isBusy():
+               busy = True
+
+        if idle is True:
+            if re.search('BUILD', b.name):
+                idle_builders.insert(0, b)
+            else:
+                idle_builders.append(b)
+        elif busy is True:
+            if re.search('BUILD', b.name):
+                busy_builders.insert(0, b)
+            else:
+                busy_builders.append(b)
         else:
-            sorted_builders.append(b)
+            if re.search('BUILD', b.name):
+                avail_builders.insert(0, b)
+            else:
+                avail_builders.append(b)
+
+    sorted_builders = idle_builders + avail_builders + busy_builders
 
     log.msg("prioritized %i builder(s): %s" % (len(sorted_builders),
         [b.name for b in sorted_builders]))


### PR DESCRIPTION
Rewrote the prioritizeBuilders function in master.cfg.
Builders that have an idle slave should be chosen before all
others. If no idle builder exists, then choose a builder
which has no substantiated slaves. Substantiation takes on the
order of 3-4 minutes. During that time, another builder's slave
may become idle. Finally, just assign to a busy builder since
all builders must be busy.

Signed-off-by: Giuseppe Di Natale <dinatale2@llnl.gov>