### PR TITLE
Addition of SUSE Linux spot instances.

### DIFF
--- a/master/builderinfo.py
+++ b/master/builderinfo.py
@@ -76,6 +76,7 @@ class EC2SlaveInfo(BuildSlaveInfo):
         region="us-west-2"
         placement=None
         spot_instance=False
+        product_description="Linux/UNIX (Amazon VPC)"
         max_spot_price=0.08
         price_multiplier=1.25
         keepalive_interval=3600
@@ -131,6 +132,8 @@ runurl """ + self.url + """bb-bootstrap.sh
                 price_multiplier=kwargs[key]
             if key=="placement":
                 placement=kwargs[key]
+            if key=="product_description":
+                product_description=kwargs[key]
 
         return EC2LatentBuildSlave(
             self.name, self.password, instance_type, ami=self.ami,
@@ -142,6 +145,7 @@ runurl """ + self.url + """bb-bootstrap.sh
             build_wait_timeout=build_wait_timeout, properties={}, locks=None,
             spot_instance=spot_instance, max_spot_price=max_spot_price, volumes=[],
             placement=placement, price_multiplier=price_multiplier,
+            product_description=product_description,
             tags={
                 "ENV"      : "DEV",
                 "Name"     : "ZFSBuilder",
@@ -157,6 +161,15 @@ class EC2LargeSlaveInfo(EC2SlaveInfo):
         return super(EC2LargeSlaveInfo, self).makeBuildSlave(
             build_wait_timeout=30 * 60, instance_type="m3.large",
             spot_instance=True, max_spot_price=0.08,
+            price_multiplier=1.25, **kwargs)
+
+# Create a large EC2 latent build slave.
+class EC2LargeSUSESlaveInfo(EC2SlaveInfo):
+    def makeBuildSlave(self, **kwargs):
+        return super(EC2LargeSUSESlaveInfo, self).makeBuildSlave(
+            build_wait_timeout=30 * 60, instance_type="m3.large",
+            spot_instance=True, max_spot_price=0.16,
+            product_description="SUSE Linux (Amazon VPC)",
             price_multiplier=1.25, **kwargs)
 
 # Create an EC2 latent test slave.

--- a/master/patches/0007-allow-spot-requests-for-non-linux-instances.patch
+++ b/master/patches/0007-allow-spot-requests-for-non-linux-instances.patch
@@ -1,0 +1,29 @@
+diff --git a/master/buildbot/buildslave/ec2.py b/master/buildbot/buildslave/ec2.py
+index 54286ab..29300f2 100644
+--- a/master/buildbot/buildslave/ec2.py
++++ b/master/buildbot/buildslave/ec2.py
+@@ -60,6 +60,7 @@ class EC2LatentBuildSlave(AbstractLatentBuildSlave):
+                  build_wait_timeout=60 * 10, properties={}, locks=None,
+                  spot_instance=False, max_spot_price=1.6, volumes=[],
+                  placement=None, price_multiplier=1.2, tags={},
++                 product_description='Linux/UNIX (Amazon VPC)',
+                  delete_vol_term=True):
+ 
+         AbstractLatentBuildSlave.__init__(
+@@ -99,6 +100,7 @@ class EC2LatentBuildSlave(AbstractLatentBuildSlave):
+         self.volumes = volumes
+         self.price_multiplier = price_multiplier
+         self.delete_vol_term = delete_vol_term
++        self.product_description = product_description
+ 
+         if None not in [placement, region]:
+             self.placement = '%s%s' % (region, placement)
+@@ -361,7 +363,7 @@ class EC2LatentBuildSlave(AbstractLatentBuildSlave):
+             '%Y-%m-%dT%H:%M:%SZ', timestamp_yesterday)
+         spot_prices = self.conn.get_spot_price_history(
+             start_time=spot_history_starttime,
+-            product_description='Linux/UNIX (Amazon VPC)',
++            product_description=self.product_description,
+             availability_zone=self.placement)
+         price_sum = 0.0
+         price_count = 0


### PR DESCRIPTION
Buildbot uses the request pricing history feature
to determine the average price for Linux/Unix type
instances only (it's hardcoded). Introduced a way
to specify the type of instance you wish to create
to the EC2 Latent Build Slave object. Also, added
a Large Slave Info object in builderinfo.py.

Be sure to apply the patch to buildbot before using
the new SUSE Large Slave Info object.

Signed-off-by: Giuseppe Di Natale <dinatale2@llnl.gov>