### PR TITLE
Bootable image: build bootable image on Fedora.

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -261,6 +261,16 @@ test_factory.addStep(ShellCommand(
     logfiles={"console" : { "filename" : "console.log", "follow" : False }},
     decodeRC={0 : SUCCESS, 1 : FAILURE, 2 : WARNINGS, 3 : SKIPPED },
     description=["zfsstress"], descriptionDone=["zfsstress"]))
+test_factory.addStep(ShellCommand(
+    workdir="build/tests/zfs-fedora-installer",
+    env={'PATH' : bin_path + ":" + zfs_path},
+    command=["runurl", bb_url + "bb-test-bootable-image.sh"],
+    haltOnFailure=False, maxTime=14400, sigtermTime=30, logEnviron=False,
+    logfiles={"console" : { "filename" : "console.log", "follow" : False },
+              "log"     : { "filename" : "output.log",  "follow" : True }},
+    decodeRC={0 : SUCCESS, 1 : FAILURE, 2 : FAILURE, 5 : FAILURE, 9 : FAILURE, 3 : SKIPPED },
+    description=["test-bootable-image"], descriptionDone=["test-bootable-image"]))
+
 
 test_factory.addStep(ShellCommand(command=["runurl", bb_url + "bb-cleanup.sh"],
     env={'PATH' : bin_path},
@@ -480,6 +490,13 @@ ubuntu14_x86_64_testslave = [
     ) for i in range(0, numtestslaves)
 ]
 
+fedora23_x86_64_testslave = [
+    ZFSEC2TestSlave(
+        name="Fedora-23-x86_64-testslave%s" % (str(i+1)),
+        ami="ami-f8709e98"
+    ) for i in range(0, numslaves)
+]
+
 #ubuntu14_i686_testslave = [
 #    ZFSEC2PVTestSlave(
 #        name="Ubuntu-14.04-i686-testslave%s" % (str(i+1)),
@@ -639,6 +656,13 @@ test_builders = [
         name="Ubuntu 14.04 x86_64 (TEST)",
         factory=test_factory,
         slavenames=[slave.name for slave in ubuntu14_x86_64_testslave],
+        tags=test_tags,
+        properties=builder_default_properties,
+    ),
+    ZFSBuilderConfig(
+        name="Fedora 23 x86_64 (TEST)",
+        factory=test_factory,
+        slavenames=[slave.name for slave in fedora23_x86_64_testslave],
         tags=test_tags,
         properties=builder_default_properties,
     ),

--- a/scripts/bb-bootstrap.sh
+++ b/scripts/bb-bootstrap.sh
@@ -212,12 +212,12 @@ Fedora*)
 
     # Install the latest kernel to reboot on to.
     if test "$BB_MODE" = "TEST"; then
-        yum -y update kernel
+        dnf -y update kernel-core
     fi
 
     # Use the debug kernel instead if indicated
     if test "$BB_KERNEL_TYPE" = "DEBUG"; then
-        yum -y install kernel-debug
+        dnf -y install kernel-debug
         set_boot_kernel
     fi
 

--- a/scripts/bb-build-packages.sh
+++ b/scripts/bb-build-packages.sh
@@ -47,8 +47,7 @@ Debian*)
     ;;
 
 Fedora*)
-    $SUDO rm *.src.rpm *.noarch.rpm >>$INSTALL_LOG 2>&1
-    $SUDO dnf -y localinstall *.rpm >>$INSTALL_LOG 2>&1 || exit 1
+    $SUDO dnf -y install *.$(arch).rpm >>$INSTALL_LOG 2>&1 || exit 1
     ;;
 
 RHEL*)

--- a/scripts/bb-dependencies.sh
+++ b/scripts/bb-dependencies.sh
@@ -59,7 +59,7 @@ Debian*)
 
 Fedora*)
     # Required development tools.
-    $SUDO dnf -y install gcc autoconf libtool gdb
+    $SUDO dnf groupinstall "C Development Tools and Libraries"
 
     # Required utilities.
     $SUDO dnf -y install git rpm-build wget curl bc \
@@ -69,6 +69,9 @@ Fedora*)
     $SUDO dnf -y install kernel-devel-$(uname -r) zlib-devel \
         libuuid-devel libblkid-devel libselinux-devel \
         xfsprogs-devel libattr-devel libacl-devel libudev-devel
+
+    # Required testing utilities (for bb-test-bootable-image.sh)
+    $SUDO dnf -y install qemu-system-x86 rsync cryptsetup
     ;;
 
 RHEL*)

--- a/scripts/bb-test-bootable-image.sh
+++ b/scripts/bb-test-bootable-image.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+
+# Check for a local cached configuration.
+if test -f /etc/buildslave; then
+    . /etc/buildslave
+fi
+
+# Custom test options will be saved in the tests directory.
+if test -f "../TEST"; then
+    . ../TEST
+fi
+
+TEST_BOOTABLE_IMAGE_SKIP=${TEST_BOOTABLE_IMAGE_SKIP:-"No"}
+if echo "$TEST_BOOTABLE_IMAGE_SKIP" | grep -Eiq "^yes$|^on$|^true$|^1$"; then
+    echo "Skipping disabled test"
+    exit 3
+fi
+
+ZFS_SH=${ZFS_SH:-"zfs.sh"}
+CONSOLE_LOG="$PWD/console.log"
+OUTPUT_LOG="$PWD/output.log"
+
+case "$BB_NAME" in
+Fedora*)
+    true
+    ;;
+
+*)
+    echo "$BB_NAME unknown platform, skipping image test" >>$OUTPUT_LOG 2>&1
+    exit 3
+    ;;
+esac
+
+# Cleanup the pool and restore any modified system state.  The console log
+# is dumped twice to maximize the odds of preserving debug information.
+cleanup()
+{
+    dmesg >$CONSOLE_LOG
+    sudo -E $ZFS_SH -u
+    dmesg >$CONSOLE_LOG
+}
+trap cleanup EXIT SIGTERM
+
+set -x
+
+TEST_BOOTABLE_IMAGE_URL=${TEST_BOOTABLE_IMAGE_URL:-"https://github.com/Rudd-O/zfs-fedora-installer/archive/master.tar.gz"}
+TEST_BOOTABLE_IMAGE_TAR=${TEST_BOOTABLE_IMAGE_TAR:-"zfs-fedora-installer.tar.gz"}
+TEST_BOOTABLE_IMAGE_POOL=${TEST_BOOTABLE_IMAGE_POOL:-"bootable_image"}
+TEST_BOOTABLE_IMAGE_VDEV=${TEST_BOOTABLE_IMAGE_VDEV:-"/var/tmp/bootable_image.img"}
+TEST_BOOTABLE_IMAGE_OPTIONS=${TEST_BOOTABLE_IMAGE_OPTIONS:-""}
+
+echo -n >$OUTPUT_LOG 2>&1
+
+sudo -E dmesg -c >/dev/null
+sudo -E $ZFS_SH || exit 1
+
+wget -qO${TEST_BOOTABLE_IMAGE_TAR} ${TEST_BOOTABLE_IMAGE_URL} || exit 1
+tar -xz --strip-components=1 -f ${TEST_BOOTABLE_IMAGE_TAR} || exit 1
+rm -f ${TEST_BOOTABLE_IMAGE_TAR}
+
+rm -rf rpms/                            >>$OUTPUT_LOG 2>&1
+mkdir -p rpms/                          >>$OUTPUT_LOG 2>&1
+cp -Rv ../../spl/*.rpm ../../zfs/*.rpm rpms/  >>$OUTPUT_LOG 2>&1
+
+sudo -E ./install-fedora-on-zfs \
+    "$TEST_BOOTABLE_IMAGE_VDEV" \
+    --pool-name="$TEST_BOOTABLE_IMAGE_POOL" \
+    --root-password=password \
+    --luks-password=password \
+    --use-prebuilt-rpms="$PWD/rpms" \
+    >>$OUTPUT_LOG 2>&1
+RESULT=$?
+
+exit $RESULT


### PR DESCRIPTION
Currently this only builds the bootable image, we can execute
the bootable image latter and test that it, in fact, boots correctly.
