### PR TITLE
Prevent Require-spl dependency from persisting to other PRs

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -787,6 +787,7 @@ from buildbot.schedulers.trysched import Try_Userpass
 from buildbot.schedulers.basic import SingleBranchScheduler
 from buildbot.changes.filter import ChangeFilter
 from buildbot.changes import filter
+import copy
 
 build_builders = [builder.name for builder in distro_arch_builders]
 test_builders = [builder.name for builder in test_builders]
@@ -812,7 +813,7 @@ class CustomSingleBranchScheduler(SingleBranchScheduler):
         return SingleBranchScheduler.gotChange(self, change, important)
 
     def getCodebaseDict(self, codebase):
-        ss = self.codebases[codebase]
+        ss = copy.deepcopy(self.codebases[codebase])
         if codebase == "spl":
             if self.spl_pull_request is not None:
                 ss['branch'] = self.spl_pull_request


### PR DESCRIPTION
When a PR is submitted with the Requires-spl keyword, all
subsequent builds will use that SPL commit instead of
defaulting back to master. Corrected the
CustomSingleBranchScheduler.getCodebaseDict function
to make a deep copy of the codebase dictionary before
modifying it.

This closes #27.

Signed-off-by: Giuseppe Di Natale <dinatale2@llnl.gov>