### PR TITLE
Provide a Requires-builders option in commit messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,19 @@ your ZFS pull request, where `PR` is an open SPL pull request number.  This
 will instruct the buildbot to use that SPL pull request rather than the
 default master branch.
 
+By default, all commits in your ZFS pull request are compiled by the BUILD
+builders.  Additionally, the top commit of your ZFS pull request is tested by
+TEST builders. However, there is the option to override which types of builder
+should be used on a per commit basis. In this case, you can add
+`Requires-builders: <style|build|test>` to your commit message. A comma
+separated list of options can be provided. Supported options are:
+
+* `style`: This commit should be built by STYLE builders
+
+* `build`: This commit should be built by BUILD builders
+
+* `test`: This commit should be built and tested by the TEST builders
+
 ### Builder Types
 
 When a new pull request is opened it is queued up for testing on all of the

--- a/master/master.cfg
+++ b/master/master.cfg
@@ -959,6 +959,13 @@ class CustomGitHubEventHandler(GitHubEventHandler):
             else:
                 category = "style,build"
 
+            # Extract any overrides for which builders need to be run for this commit
+            # Requires-builders: build test style
+            category_pattern = '^Requires-builders:\s*([ ,a-zA-Z0-9]+)'
+            m = re.search(category_pattern, comments, re.I | re.M)
+            if m is not None:
+                category = m.group(1).lower();
+
             # Annotate every commit with 'Requires-spl' when missing.
             comments = commit['commit']['message'] + "\n\n"
             if spl_pull_request:


### PR DESCRIPTION
Provide a Requires-builders option to enable overrides
for builder selection on a per commit basis. The valid
options for the new option are 'build', 'test', and
'perf'. Update the README with information about the
newe Requires-builders option.

Signed-off-by: Giuseppe Di Natale dinatale2@llnl.gov
