### PR TITLE
Implement a STYLE builder

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,12 @@ default master branch.
 ### Builder Types
 
 When a new pull request is opened it is queued up for testing on all of the
-available builders.  There are two primary types of builders:
+available builders.  There are three primary types of builders:
+
+* STYLE: These builders are responsible for performing static analysis.
+  Currently, style checking and linting is performed for each submitted
+  change. Changes are required to pass static analysis before being
+  accepted.
 
 * BUILD: These builders are responsible for verifying that a change
   doesn't break the build on a given platform.  Every commit in the pull

--- a/master/master.cfg
+++ b/master/master.cfg
@@ -73,6 +73,35 @@ def do_step_build_spl(step):
 def do_step_build_zfs(step):
     return do_step_build(step, 'buildzfs')
 
+style_factory = util.BuildFactory()
+
+style_factory.addStep(Git(repourl=zfs_repo, workdir="build/zfs",
+    mode="full", method="clobber", codebase="zfs",
+    logEnviron=False, getDescription=True,
+    description=["cloning"], descriptionDone=["cloned"]))
+style_factory.addStep(ShellCommand(
+    workdir="build/zfs", env={'PATH' : bin_path,
+        'CONFIG_OPTIONS' : '--with-config=srpm'},
+    command=["runurl", bb_url + "bb-build-zfs.sh"],
+    haltOnFailure=True, logEnviron=False,
+    logfiles={"configure"  : { "filename" : "configure.log", "follow" : True },
+              "config.log" : { "filename" : "config.log",    "follow" : True },
+              "make"       : { "filename" : "make.log",      "follow" : True }},
+    decodeRC={0 : SUCCESS, 1 : FAILURE, 2 : WARNINGS, 3 : SKIPPED },
+    description=["building zfs"], descriptionDone=["built zfs"]))
+style_factory.addStep(ShellCommand(command=["make", "checkstyle"],
+    env={'PATH' : bin_path},
+    workdir="build/zfs", logEnviron=False,
+    haltOnFailure=False, flunkOnWarnings=True,
+    decodeRC={0 : SUCCESS, 1 : FAILURE, 2 : WARNINGS, 3 : SKIPPED },
+    description=["checking style"], descriptionDone=["checked style"]))
+style_factory.addStep(ShellCommand(command=["make", "lint"],
+    env={'PATH' : bin_path},
+    workdir="build/zfs", logEnviron=False,
+    haltOnFailure=False, flunkOnWarnings=True,
+    decodeRC={0 : SUCCESS, 1 : FAILURE, 2 : WARNINGS, 3 : SKIPPED },
+    description=["checking lint"], descriptionDone=["checked lint"]))
+
 build_factory = util.BuildFactory()
 
 build_factory.addStep(ShellCommand(
@@ -134,20 +163,6 @@ build_factory.addStep(ShellCommand(
     description=["building zfs"], descriptionDone=["built zfs"],
     doStepIf = do_step_build_zfs,
     hideStepIf=lambda results, s: results==SKIPPED))
-
-build_factory.addStep(ShellCommand(command=["make", "checkstyle"],
-    env={'PATH' : bin_path},
-    workdir="build/zfs", logEnviron=False,
-    haltOnFailure=False, flunkOnWarnings=True,
-    decodeRC={0 : SUCCESS, 1 : FAILURE, 2 : WARNINGS, 3 : SKIPPED },
-    description=["checking style"], descriptionDone=["checked style"]))
-
-build_factory.addStep(ShellCommand(command=["make", "lint"],
-    env={'PATH' : bin_path},
-    workdir="build/zfs", logEnviron=False,
-    haltOnFailure=False, flunkOnWarnings=True,
-    decodeRC={0 : SUCCESS, 1 : FAILURE, 2 : WARNINGS, 3 : SKIPPED },
-    description=["checking lint"], descriptionDone=["checked lint"]))
 
 #
 # Perform a package build with debugging enabled, install the packages,
@@ -386,6 +401,16 @@ def prioritizeBuilders(buildmaster, builders):
 
 c['prioritizeBuilders'] = prioritizeBuilders
 
+# STYLE BUILD SLAVES
+numstyleslaves = 1
+
+style_slaves = [
+    ZFSEC2BuildSlave(
+        name="Amazon-2015.09-x86_64-styleslave%s" % (str(i+1)),
+        ami="ami-f1d69891"
+    ) for i in range(0, numstyleslaves)
+]
+
 # DISTRO BUILD SLAVES
 numslaves = 1
 
@@ -525,11 +550,23 @@ ubuntu14_x86_64_testslave = [
 
 test_slaves = amazon_x86_64_testslave + amazon_x86_64_simd_testslave + centos6_x86_64_testslave + centos7_x86_64_testslave + debian8_x86_64_testslave + ubuntu14_x86_64_testslave
 
-all_slaves = distro_slaves + arch_slaves + test_slaves
+all_slaves = style_slaves + distro_slaves + arch_slaves + test_slaves
 
+style_tags = [ "Style" ]
 build_distro_tags = [ "Distributions" ]
 build_arch_tags = [ "Architectures" ]
 test_tags = [ "Tests" ]
+
+style_builders = [
+    #### Style builders
+    ZFSBuilderConfig(
+        name="Amazon 2015.09 x86_64 (STYLE)",
+        factory=style_factory,
+        slavenames=[slave.slavename for slave in style_slaves],
+        tags=style_tags,
+        properties=builder_default_properties,
+    ),
+]
 
 distro_arch_builders = [
     #### Distro builders
@@ -687,7 +724,7 @@ test_builders = [
 #    ),
 ]
 
-all_builders = distro_arch_builders + test_builders
+all_builders = style_builders + distro_arch_builders + test_builders
 
 c['slaves'] = all_slaves 
 c['builders'] = all_builders 


### PR DESCRIPTION
Place linting and style checking into its own builder.
This will provide developers with faster feedback
regarding style issues and remove the redundant checks
that go on for each BUILD builder.

Signed-off-by: Giuseppe Di Natale <dinatale2@llnl.gov>