### PR TITLE
Use flake8 instead of pep8

### DIFF
--- a/scripts/bb-dependencies.sh
+++ b/scripts/bb-dependencies.sh
@@ -21,13 +21,15 @@ Amazon*)
     # Required utilities.
     $SUDO yum -y install git rpm-build wget curl bc fio acl sysstat \
         mdadm lsscsi parted attr dbench watchdog ksh
-    $SUDO yum -y install --enablerepo=epel cppcheck python-pep8
+    $SUDO yum -y install --enablerepo=epel cppcheck
 
     # Required development libraries
     $SUDO yum -y install kernel-devel-$(uname -r) \
         zlib-devel libuuid-devel libblkid-devel libselinux-devel \
         xfsprogs-devel libattr-devel libacl-devel libudev-devel \
         device-mapper-devel
+
+    $SUDO pip --quiet install flake8
     ;;
 
 CentOS*)


### PR DESCRIPTION
Use flake8 to perform python style
checking because pep8 has been deprecated.

Signed-off-by: Giuseppe Di Natale <dinatale2@llnl.gov>