### PR TITLE
Allow builds to run on specific BUILD builders

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,12 +45,17 @@ By default, all commits in your ZFS pull request are compiled by the BUILD
 builders.  Additionally, the top commit of your ZFS pull request is tested by
 TEST builders. However, there is the option to override which types of builder
 should be used on a per commit basis. In this case, you can add
-`Requires-builders: <style|build|test>` to your commit message. A comma
-separated list of options can be provided. Supported options are:
+`Requires-builders: <style|build|arch|distro|test>` to your
+commit message. A comma separated list of options can be
+provided. Supported options are:
 
 * `style`: This commit should be built by STYLE builders
 
-* `build`: This commit should be built by BUILD builders
+* `build`: This commit should be built by all BUILD builders
+
+* `arch`: This commit should be built by BUILD builders tagged as 'Architectures'
+
+* `distro`: This commit should be built by BUILD builders tagged as 'Distributions'
 
 * `test`: This commit should be built and tested by the TEST builders
 

--- a/master/master.cfg
+++ b/master/master.cfg
@@ -1057,10 +1057,17 @@ c['schedulers'].append(CustomSingleBranchScheduler(
 
 # This scheduler is for pull requests.
 c['schedulers'].append(CustomSingleBranchScheduler(
-    name="pull-request-build-scheduler",
-    builderNames=distro_builders + arch_builders,
+    name="pull-request-build-distro-scheduler",
+    builderNames=distro_builders,
     codebases=default_codebases,
-    change_filter=filter.ChangeFilter(category_re=".*build.*")))
+    change_filter=filter.ChangeFilter(category_re=".*(build|distro).*")))
+
+# This scheduler is for pull requests.
+c['schedulers'].append(CustomSingleBranchScheduler(
+    name="pull-request-build-arch-scheduler",
+    builderNames=arch_builders,
+    codebases=default_codebases,
+    change_filter=filter.ChangeFilter(category_re=".*(build|arch).*")))
 
 # This scheduler is for pull requests.
 c['schedulers'].append(CustomSingleBranchScheduler(


### PR DESCRIPTION
Place the Distribution and Architecture BUILD builders
on separate schedulers so they can be started independently.
Both schedulers will still accept the `build` category.

Signed-off-by: Giuseppe Di Natale <dinatale2@llnl.gov>