### PR TITLE
Add NFS and Samba server dependency for ZFS Test Suite

### DIFF
--- a/scripts/bb-dependencies.sh
+++ b/scripts/bb-dependencies.sh
@@ -20,7 +20,7 @@ Amazon*)
 
     # Required utilities.
     $SUDO yum -y install git rpm-build wget curl bc fio acl sysstat \
-        mdadm lsscsi parted attr dbench watchdog ksh
+        mdadm lsscsi parted attr dbench watchdog ksh nfs-utils samba
     $SUDO yum -y install --enablerepo=epel cppcheck pax-utils
 
     # Required development libraries
@@ -38,7 +38,7 @@ CentOS*)
 
     # Required utilities.
     $SUDO yum -y install git rpm-build wget curl bc fio acl sysstat \
-        mdadm lsscsi parted attr dbench watchdog ksh
+        mdadm lsscsi parted attr dbench watchdog ksh nfs-utils samba
 
     # Required development libraries
     $SUDO yum -y install kernel-devel \
@@ -54,7 +54,8 @@ Debian*)
 
     # Required utilities.
     $SUDO apt-get --yes install git alien fakeroot wget curl bc fio acl \
-        sysstat lsscsi parted gdebi attr dbench watchdog ksh
+        sysstat lsscsi parted gdebi attr dbench watchdog ksh nfs-kernel-server \
+        samba
 
     # Required development libraries
     $SUDO apt-get --yes install linux-headers-$(uname -r) \
@@ -68,7 +69,7 @@ Fedora*)
 
     # Required utilities.
     $SUDO dnf -y install git rpm-build wget curl bc fio acl sysstat \
-        mdadm lsscsi parted attr dbench watchdog ksh
+        mdadm lsscsi parted attr dbench watchdog ksh nfs-utils samba
 
     # Required development libraries
     $SUDO dnf -y install kernel-devel-$(uname -r) zlib-devel \
@@ -91,7 +92,7 @@ RHEL*)
 
     # Required utilities.
     $SUDO yum -y install git rpm-build wget curl bc fio acl sysstat \
-        mdadm lsscsi parted attr dbench watchdog ksh
+        mdadm lsscsi parted attr dbench watchdog ksh nfs-utils samba
 
     # Required development libraries
     $SUDO yum -y $EXTRA_REPO install kernel-devel-$(uname -r) zlib-devel \
@@ -106,7 +107,8 @@ SUSE*)
 
     # Required utilities.
     $SUDO zypper --non-interactive install git rpm-build wget curl bc \
-        fio acl sysstat mdadm lsscsi parted attr ksh
+        fio acl sysstat mdadm lsscsi parted attr ksh nfs-kernel-server \
+        samba
 
     # Required development libraries
     $SUDO zypper --non-interactive install kernel-devel zlib-devel \
@@ -120,7 +122,8 @@ Ubuntu*)
 
     # Required utilities.
     $SUDO apt-get --yes install git alien fakeroot wget curl bc fio acl \
-        sysstat mdadm lsscsi parted gdebi attr dbench watchdog ksh
+        sysstat mdadm lsscsi parted gdebi attr dbench watchdog ksh \
+        nfs-kernel-server samba
 
     # Required development libraries
     $SUDO apt-get --yes install linux-headers-$(uname -r) \

--- a/scripts/bb-test-prepare.sh
+++ b/scripts/bb-test-prepare.sh
@@ -101,4 +101,63 @@ if echo "$TEST_PREPARE_WATCHDOG" | grep -Eiq "^yes$|^on$|^true$|^1$"; then
      esac
 fi
 
+# Start both NFS and Samba servers, needed by the ZFS Test Suite to run
+# zfs_share and zfs_unshare scripts.
+TEST_PREPARE_SHARES=${TEST_PREPARE_SHARES:-"Yes"}
+if echo "$TEST_PREPARE_SHARES" | grep -Eiq "^yes$|^on$|^true$|^1$"; then
+    case "$BB_NAME" in
+    Amazon*)
+        $SUDO /etc/init.d/rpcbind start
+        $SUDO /etc/init.d/nfs start
+        $SUDO /etc/init.d/smb start
+        ;;
+
+    CentOS*)
+        if cat /etc/redhat-release | grep -Eq "6."; then
+            $SUDO /etc/init.d/rpcbind start
+            $SUDO /etc/init.d/nfs start
+            $SUDO /etc/init.d/smb start
+        elif cat /etc/redhat-release | grep -Eq "7."; then
+            $SUDO systemctl start nfs-server
+            $SUDO systemctl start smb
+        fi
+        ;;
+
+    Debian*)
+        $SUDO systemctl start nfs-kernel-server
+        $SUDO systemctl start samba
+        ;;
+
+    Fedora*)
+        $SUDO systemctl start nfs-server
+        $SUDO systemctl start smb
+        ;;
+
+    RHEL*)
+        if cat /etc/redhat-release | grep -Eq "6."; then
+            $SUDO /etc/init.d/rpcbind start
+            $SUDO /etc/init.d/nfs start
+            $SUDO /etc/init.d/smb start
+        elif cat /etc/redhat-release | grep -Eq "7."; then
+            $SUDO systemctl start nfs-server
+            $SUDO systemctl start smb
+        fi
+        ;;
+
+    SUSE*)
+        $SUDO systemctl start nfsserver
+        $SUDO systemctl start smb
+        ;;
+
+    Ubuntu*)
+        $SUDO service nfs-kernel-server start
+        $SUDO service smbd start
+        ;;
+
+    *)
+        echo "$BB_NAME unknown platform"
+        ;;
+     esac
+fi
+
 exit 0


### PR DESCRIPTION
We need both NFS and Samba servers to run `zfs_share` and `zfs_unshare` scripts in the ZFS Test Suite.

Once this is merged i'll try enabling those tests in https://github.com/zfsonlinux/zfs/pull/5367.

I don't know all these distros very well, i hope i got the package names right.