### PR TITLE
Requires-builder should accept the option 'all'

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -1080,6 +1080,12 @@ class CustomGitHubEventHandler(GitHubEventHandler):
             if m is not None:
                 category = m.group(1).lower();
 
+                # if Requires-builders contains 'all', then all builders should run
+                all_pattern = '.*all.*'
+                m = re.search(all_pattern, category, re.I | re.M)
+                if m is not None:
+                    category = "style,build,test,perf" 
+
             # Annotate every commit with 'Requires-spl' when missing.
             comments = commit['commit']['message'] + "\n\n"
             if spl_pull_request:


### PR DESCRIPTION
When a commit message contains a Requires-builder
directive, check for 'all'. If 'all' is present, then
all available builders should be used.

Signed-off-by: Giuseppe Di Natale <dinatale2@llnl.gov>