### PR TITLE
Prioritise building the head (final) commit of each pull request.

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -1110,6 +1110,8 @@ class CustomGitHubEventHandler(GitHubEventHandler):
                                        commit['commit']['committer']['email']),
                 'comments' : comments,
                 'files' : changed_files,
+                'commit_part' : commits_cur,
+                'commits_total' : commits_num,
             }
 
             if callable(self._codebase):


### PR DESCRIPTION
The last commits that make up long commit chains will be delayed when
shorter commit chains are pushed.  A large number of short commit chains
may starve them for long times.  Perhaps some increased priority for
waiting a long time (say 1 part unit per 5 h) should be employed.

Probably better to start out by letting chain-internal commits build in
original order, and just prioritise the head commits?

Note: this patch is untested!
Most notably: I am not sure if request.source.commit_part is a way that works
to access the commit_part item of the change request.
Feel free to change as needed!

See #40 