### PR TITLE
Add the Requires-builder all option to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,9 +45,11 @@ By default, all commits in your ZFS pull request are compiled by the BUILD
 builders.  Additionally, the top commit of your ZFS pull request is tested by
 TEST builders. However, there is the option to override which types of builder
 should be used on a per commit basis. In this case, you can add
-`Requires-builders: <style|build|arch|distro|test|perf>` to your
+`Requires-builders: <all|style|build|arch|distro|test|perf>` to your
 commit message. A comma separated list of options can be
 provided. Supported options are:
+
+* `all`: This commit should be built by all available builders
 
 * `style`: This commit should be built by STYLE builders
 


### PR DESCRIPTION
Add information about the Requires-builder all option
to the README.

Signed-off-by: Giuseppe Di Natale <dinatale2@llnl.gov>