### PR TITLE
Avoid linking pull requests to incorrect OpenZFS issue

### DIFF
--- a/scripts/openzfs-tracking.sh
+++ b/scripts/openzfs-tracking.sh
@@ -234,7 +234,7 @@ do
 
 	# Match issue against any open pull requests.
 	ZFSONLINUX_PR=$(echo $ZFSONLINUX_PRS | jq -r ".[] | select(.title | \
-	    contains(\"OpenZFS $OPENZFS_ISSUE\")) | { html_url: .html_url }" | \
+	    contains(\"OpenZFS $OPENZFS_ISSUE \")) | { html_url: .html_url }" | \
 	    grep html_url | cut -f2- -d':' | tr -d ' "')
 	ZFSONLINUX_REGEX="^(openzfs|illumos)+.*[ #]+$OPENZFS_ISSUE[ ,]+*.*"
 


### PR DESCRIPTION
Include expected whitespace when attempting to search
github pull requests for a port of OpenZFS patch. There
were cases when 3 digit OpenZFS issue numbers were paired
with 4 digit OpenZFS issue numbers. Example: OpenZFS 734
was paired with a pull request for OpenZFS 7348.

Signed-off-by: Giuseppe Di Natale <dinatale2@llnl.gov>