### PR TITLE
Add none to Requires-builders

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,11 +45,13 @@ By default, all commits in your ZFS pull request are compiled by the BUILD
 builders.  Additionally, the top commit of your ZFS pull request is tested by
 TEST builders. However, there is the option to override which types of builder
 should be used on a per commit basis. In this case, you can add
-`Requires-builders: <all|style|build|arch|distro|test|perf>` to your
+`Requires-builders: <none|all|style|build|arch|distro|test|perf>` to your
 commit message. A comma separated list of options can be
 provided. Supported options are:
 
 * `all`: This commit should be built by all available builders
+
+* `none`: This commit should not be built by any builders
 
 * `style`: This commit should be built by STYLE builders
 

--- a/master/master.cfg
+++ b/master/master.cfg
@@ -1067,11 +1067,17 @@ class CustomGitHubEventHandler(GitHubEventHandler):
                 category = "style,build"
 
             # Extract any overrides for which builders need to be run for this commit
-            # Requires-builders: style build arch distro test perf
+            # Requires-builders: style build arch distro test perf none
             category_pattern = '^Requires-builders:\s*([ ,a-zA-Z0-9]+)'
             m = re.search(category_pattern, comments, re.I | re.M)
             if m is not None:
                 category = m.group(1).lower();
+
+                # if Requires-builders contains 'none', then skip this commit
+                none_pattern = '.*none.*'
+                m = re.search(none_pattern, category, re.I | re.M)
+                if m is not None:
+                    continue
 
                 # if Requires-builders contains 'all', then all builders should run
                 all_pattern = '.*all.*'


### PR DESCRIPTION
There are cases where a developer may
want to submit a pull request for review,
but not run it through testing. This could
unnecessary traffic to the buildbot if
used appropriately. This could also be
good for WIP pull requests where feedback
is necessary anyways.

Signed-off-by: Giuseppe Di Natale <dinatale2@llnl.gov>

NOTE: I haven't tested this yet. Just throwing this out there because I didn't want to run the test suite on my zfs-tests single test feature yet.