### PR TITLE
Move Amazon SIMD test builder to the perf category

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -719,13 +719,6 @@ amazon_x86_64_testslave = [
     ) for i in range(0, numtestslaves)
 ]
 
-amazon_x86_64_simd_testslave = [
-    ZFSEC2VectorTestSlave(
-        name="Amazon-2015.09-x86_64-simd-testslave%s" % (str(i+1)),
-        ami="ami-def7bebe"
-    ) for i in range(0, numtestslaves)
-]
-
 centos6_x86_64_testslave = [
     ZFSEC2TestSlave(
         name="CentOS-6-x86_64-testslave%s" % (str(i+1)),
@@ -768,9 +761,16 @@ ubuntu16_x86_64_kmemleak_testslave = [
     ) for i in range(0, numtestslaves)
 ]
 
-test_slaves = amazon_x86_64_testslave + amazon_x86_64_simd_testslave + centos6_x86_64_testslave + centos7_x86_64_testslave + centos7_x86_64_ml_testslave + ubuntu14_x86_64_testslave + ubuntu14_i686_testslave + ubuntu16_x86_64_kmemleak_testslave
+test_slaves = amazon_x86_64_testslave + centos6_x86_64_testslave + centos7_x86_64_testslave + centos7_x86_64_ml_testslave + ubuntu14_x86_64_testslave + ubuntu14_i686_testslave + ubuntu16_x86_64_kmemleak_testslave
 
 numperfslaves = 2
+
+amazon_x86_64_simd_perfslave = [
+    ZFSEC2VectorTestSlave(
+        name="Amazon-2015.09-x86_64-simd-perfslave%s" % (str(i+1)),
+        ami="ami-def7bebe"
+    ) for i in range(0, numtestslaves)
+]
 
 amazon_x86_64_perfslave = [
     ZFSEC2PerfTestSlave(
@@ -779,7 +779,7 @@ amazon_x86_64_perfslave = [
     ) for i in range(0, numperfslaves)
 ]
 
-perf_slaves = amazon_x86_64_perfslave
+perf_slaves = amazon_x86_64_perfslave + amazon_x86_64_simd_perfslave
 
 all_slaves = style_slaves + distro_slaves + arch_slaves + test_slaves + perf_slaves
 
@@ -916,13 +916,6 @@ test_builders = [
         properties=builder_release_properties,
     ),
     ZFSBuilderConfig(
-        name="Amazon 2015.09 x86_64 SIMD (TEST)",
-        factory=test_factory,
-        slavenames=[slave.name for slave in amazon_x86_64_simd_testslave],
-        tags=test_tags,
-        properties=builder_default_properties,
-    ),
-    ZFSBuilderConfig(
         name="CentOS 6.7 x86_64 (TEST)",
         factory=test_factory,
         slavenames=[slave.name for slave in centos6_x86_64_testslave],
@@ -974,6 +967,13 @@ perf_builders = [
         slavenames=[slave.name for slave in amazon_x86_64_perfslave],
         tags=perf_tags,
         properties=builder_perf_properties,
+    ),
+    ZFSBuilderConfig(
+        name="Amazon 2015.09 x86_64 SIMD (PERF)",
+        factory=test_factory,
+        slavenames=[slave.name for slave in amazon_x86_64_simd_perfslave],
+        tags=perf_tags,
+        properties=builder_default_properties,
     ),
 ]
 


### PR DESCRIPTION
The Amazon SIMD test builder should only be triggerer
conditionally the vectorization code won't change
frequently enough and vectorization is a performance
improvement as well.

By default, performance builders will run the
perf-regression runfile. You can change it by
setting TEST_ZFSTESTS_RUNFILE in the TEST file found
at the top level of the zfs tree.

Signed-off-by: Giuseppe Di Natale <dinatale2@llnl.gov>