### PR TITLE
Move STYLE slaves to Ubuntu 16.04

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -607,8 +607,8 @@ numstyleslaves = 1
 
 style_slaves = [
     ZFSEC2BuildSlave(
-        name="Amazon-2015.09-x86_64-styleslave%s" % (str(i+1)),
-        ami="ami-def7bebe"
+        name="Ubuntu-16.04-x86_64-styleslave%s" % (str(i+1)),
+        ami="ami-429edd22"
     ) for i in range(0, numstyleslaves)
 ]
 
@@ -792,7 +792,7 @@ perf_tags = [ "Performance" ]
 style_builders = [
     #### Style builders
     ZFSBuilderConfig(
-        name="Amazon 2015.09 x86_64 (STYLE)",
+        name="Ubuntu 16.04 x86_64 (STYLE)",
         factory=style_factory,
         slavenames=[slave.slavename for slave in style_slaves],
         tags=style_tags,

--- a/scripts/bb-bootstrap.sh
+++ b/scripts/bb-bootstrap.sh
@@ -296,11 +296,11 @@ SUSE*)
 Ubuntu*)
     while [ -s /var/lib/dpkg/lock ]; do sleep 1; done
     apt-get --yes update
+    apt-get --yes install gcc python-pip python-dev
 
     # Relying on the pip version of the buildslave is more portable but
     # slower to bootstrap.  By default prefer the packaged version.
     if test $BB_USE_PIP -ne 0; then
-        apt-get --yes install gcc python-pip python-dev
         pip --quiet install buildbot-slave
         BUILDSLAVE="/usr/local/bin/buildslave"
     else

--- a/scripts/bb-dependencies.sh
+++ b/scripts/bb-dependencies.sh
@@ -120,6 +120,8 @@ Ubuntu*)
     # Required development tools.
     $SUDO apt-get --yes install build-essential autoconf libtool gdb
 
+    $SUDO apt-get --yes install cppcheck pax-utils shellcheck
+
     # Required utilities.
     $SUDO apt-get --yes install git alien fakeroot wget curl bc fio acl \
         sysstat mdadm lsscsi parted gdebi attr dbench watchdog ksh \
@@ -129,6 +131,8 @@ Ubuntu*)
     $SUDO apt-get --yes install linux-headers-$(uname -r) \
         zlib1g-dev uuid-dev libblkid-dev libselinux-dev \
         xfslibs-dev libattr1-dev libacl1-dev libudev-dev libdevmapper-dev
+
+    $SUDO pip --quiet install flake8
     ;;
 
 *)


### PR DESCRIPTION
Newer versions of style checking tools
such as cppcheck and shellcheck are available
via apt-get. Amazon's OS appears to be based
on RHEL/CentOS 6 which is dated.

Signed-off-by: Giuseppe Di Natale <dinatale2@llnl.gov>