### PR TITLE
Silence git branch -D when merging a patch

### DIFF
--- a/scripts/openzfs-merge.sh
+++ b/scripts/openzfs-merge.sh
@@ -124,7 +124,7 @@ merge() {
 	
 	echo -e "${LGREEN} - OpenZFS issue #$OPENZFS_ISSUE $OPENZFS_COMMIT ${NORMAL}"
 	echo -e "${LGREEN} Checkout new branch ${NORMAL}"
-	git branch -D "autoport-oz$OPENZFS_ISSUE"
+	git branch -D "autoport-oz$OPENZFS_ISSUE" > /dev/null
 	git checkout -b "autoport-oz$OPENZFS_ISSUE"
 	
 	echo -e "${LGREEN} Cherry-pick... ${NORMAL}"


### PR DESCRIPTION
Prior to creating a new branch during a merge,
git branch -D is called. It is possible that
the branch being deleted doesn't exist, the
error shouldn't show up.

Signed-off-by: Giuseppe Di Natale <dinatale2@llnl.gov>