### PR TITLE
Disable aio xfstests

### DIFF
--- a/scripts/bb-test-xfstests.sh
+++ b/scripts/bb-test-xfstests.sh
@@ -83,10 +83,11 @@ sudo -E $ZPOOL create -m legacy -O acltype=posixacl \
 #
 # Run xfstests skipping tests are currently unsupported
 # -zfs Filesystem type 'zfs'
+# -x aio      - Skip aio tests until xfstest is updated
 # -x dio      - Skip dio tests not yet implemented
 # -x sendfile - Skip sendfile tests not yet implemented
 #
-sudo -E $XFSTESTS -zfs -x dio -x sendfile -x user &
+sudo -E $XFSTESTS -zfs -x aio -x dio -x sendfile -x user &
 CHILD=$!
 wait $CHILD
 RESULT=$?


### PR DESCRIPTION
The aio xfstest cases were previously disabled by virtue of the
required libraries not being installed in the test images.  The
updated Amazon AMI includes the required libraries which results
in these test cases now being run and failing.  Explicitly disable
these test cases until they can be fully investigated.

Signed-off-by: Brian Behlendorf <behlendorf1@llnl.gov>