### PR TITLE
Add an additional STYLE buildslave

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -594,7 +594,7 @@ def prioritizeBuilders(buildmaster, builders):
 c['prioritizeBuilders'] = prioritizeBuilders
 
 # STYLE BUILD SLAVES
-numstyleslaves = 1
+numstyleslaves = 2
 
 style_slaves = [
     ZFSEC2StyleSlave(


### PR DESCRIPTION
Speed up style checking by adding an additional
STYLE buildslave. This hopefully will improve reliability
when we end up losing a slave.

Signed-off-by: Giuseppe Di Natale <dinatale2@llnl.gov>