### PR TITLE
KILLED tests should result in a warning

### DIFF
--- a/scripts/bb-test-zfstests.sh
+++ b/scripts/bb-test-zfstests.sh
@@ -71,8 +71,8 @@ $ZFSTESTS $TEST_ZFSTESTS_OPTIONS \
 RESULT=$?
 
 if [ $RESULT -eq 0 ]; then
-    # FAILURE: One or more test cases failed.
-    grep "\[FAIL\]" log && RESULT=1
+	grep "\[KILLED\]" log && RESULT=2  # WARNING
+	grep "\[FAIL\]" log && RESULT=1    # FAILURE
 fi
 
 if $(sudo -E test -e "$KMEMLEAK_FILE"); then


### PR DESCRIPTION
Test cases which were KILLED and not FAILED would result
in the over status still being SUCCESS.  Update the script
so a KILLED test results in a WARNINGS status (2).  Any
FAILED test will still resulted in a FAILURE overall status.