### PR TITLE
Detect when OOM-killer activity occurs

### DIFF
--- a/scripts/bb-test-prepare.sh
+++ b/scripts/bb-test-prepare.sh
@@ -22,6 +22,15 @@ SUDO="sudo -E"
 
 set -x
 
+# Attempt to set oom_score_adj for buildslave to prevent
+# it from being targeted by the oom-killer
+if test -f "$BB_DIR/twistd.pid"; then
+    pid=$(cat "$BB_DIR/twistd.pid")
+    if test -f "/proc/${pid}/oom_score_adj"; then
+        $SUDO echo -1000 > /proc/${pid}/oom_score_adj
+    fi
+fi
+
 # Create a TEST file which includes parameters which may appear in a top
 # level TEST file or the most recent git commit message.
 rm -f $TEST_FILE

--- a/scripts/bb-test-xfstests.sh
+++ b/scripts/bb-test-xfstests.sh
@@ -92,6 +92,11 @@ CHILD=$!
 wait $CHILD
 RESULT=$?
 
+if $(dmesg | grep "oom-killer"); then
+	echo "Out-of-memory (OOM) killer invocation detected"
+	[ $RESULT -eq 0 ] && RESULT=2
+fi
+
 if $(sudo -E test -e "$KMEMLEAK_FILE"); then
 	# Scan must be run twice to ensure all leaks are detected.
 	sudo -E sh -c "echo scan >$KMEMLEAK_FILE"

--- a/scripts/bb-test-zfsstress.sh
+++ b/scripts/bb-test-zfsstress.sh
@@ -85,6 +85,11 @@ RESULT=$?
 # close any resources in the mount point so it can be cleanly unmounted.
 sleep 5
 
+if $(dmesg | grep "oom-killer"); then
+	echo "Out-of-memory (OOM) killer invocation detected"
+	[ $RESULT -eq 0 ] && RESULT=2
+fi
+
 if $(sudo -E test -e "$KMEMLEAK_FILE"); then
 	# Scan must be run twice to ensure all leaks are detected.
 	sudo -E sh -c "echo scan >$KMEMLEAK_FILE"

--- a/scripts/bb-test-zfstests.sh
+++ b/scripts/bb-test-zfstests.sh
@@ -75,6 +75,11 @@ if [ $RESULT -eq 0 ]; then
 	grep "\[FAIL\]" log && RESULT=1    # FAILURE
 fi
 
+if $(dmesg | grep "oom-killer"); then
+	echo "Out-of-memory (OOM) killer invocation detected"
+	[ $RESULT -eq 0 ] && RESULT=2
+fi
+
 if $(sudo -E test -e "$KMEMLEAK_FILE"); then
 	# Scan must be run twice to ensure all leaks are detected.
 	sudo -E sh -c "echo scan >$KMEMLEAK_FILE"


### PR DESCRIPTION
Print a message if OOM-killer activity is detected
in console logs during zfstests, xfstests, and zfsstress.

Blacklist the buildslave process from being OOM-killed.

Signed-off-by: Giuseppe Di Natale <dinatale2@llnl.gov>