### PR TITLE
Generate correct commit message after cherry-pick

### DIFF
--- a/scripts/openzfs-merge.sh
+++ b/scripts/openzfs-merge.sh
@@ -214,7 +214,11 @@ prepare_manual() {
 		return 1
 	fi
 
-	echo -e "${LRED}$OPENZFS_COMMIT cherry-pick was successful${NORMAL}"
+	generate_desc
+	add_desc_to_commit
+	push_to_github
+
+	echo -e "${LGREEN}$OPENZFS_COMMIT cherry-pick was successful${NORMAL}"
 	return 0
 }
 


### PR DESCRIPTION
Generate an OpenZFS style commit message after cherry-picking
a patch.

The successful cherry-pick message prints out in red.
It should print out in green to give a visual indication
of success.

Signed-off-by: Giuseppe Di Natale <dinatale2@llnl.gov>