### PR TITLE
ZFS Tests step needs to handle non-zero return code

### DIFF
--- a/scripts/bb-test-zfstests.sh
+++ b/scripts/bb-test-zfstests.sh
@@ -68,9 +68,9 @@ $ZFSTESTS $TEST_ZFSTESTS_OPTIONS \
     -d $TEST_ZFSTESTS_DIR \
     -s $TEST_ZFSTESTS_DISKSIZE \
     -r $TEST_ZFSTESTS_RUNFILE
-RESULT=$?
+RC=$?
 
-if [ $RESULT -eq 0 ]; then
+if [ $RC -ne 0 ]; then
 	grep "\[KILLED\]" log && RESULT=2  # WARNING
 	grep "\[FAIL\]" log && RESULT=1    # FAILURE
 fi


### PR DESCRIPTION
zfs-tests.sh can now return a non-zero return code due to
recent changes to how test-runner exits. bb-test-zfstests.sh
needs to expect those new error codes.

Signed-off-by: Giuseppe Di Natale <dinatale2@llnl.gov>