### PR TITLE
Add extra to Ubuntu module search path

### DIFF
--- a/scripts/bb-bootstrap.sh
+++ b/scripts/bb-bootstrap.sh
@@ -321,6 +321,7 @@ Ubuntu*)
     echo "buildbot  ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
     sed -i.bak 's/ requiretty/ !requiretty/' /etc/sudoers
     sed -i.bak '/secure_path/a\Defaults exempt_group+=buildbot' /etc/sudoers
+    sed -i.bak 's/updates/extra updates/' /etc/depmod.d/ubuntu.conf
     ;;
 
     # Standardize ephemeral storage so it's available under /mnt.


### PR DESCRIPTION
Adding 'extra' to the depmod search path will cause depmod to
preferentially load the new kmods built by buildbot over the
distribution provided versions.  This is needed for doing testing
on current versions of Ubuntu which provide a version of ZFS.