### PR TITLE
Build lustre on BUILD builders

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -17,14 +17,17 @@ web_url = "http://build.zfsonlinux.org/"
 spl_repo = "https://github.com/zfsonlinux/spl.git"
 zfs_repo = "https://github.com/zfsonlinux/zfs.git"
 linux_repo = "https://github.com/torvalds/linux.git"
+lustre_repo = "git://git.hpdd.intel.com/fs/lustre-release.git"
 zfs_path = "/usr/libexec/zfs:/usr/share/zfs:/usr/lib/rpm/zfs:/usr/lib/zfs"
 bin_path = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 
 all_repositories = {
     "https://github.com/torvalds/linux" : 'linux',
+    "git://git.hpdd.intel.com/fs/lustre-release" : 'lustre',
     "https://github.com/zfsonlinux/spl" : 'spl',
     "https://github.com/zfsonlinux/zfs" : 'zfs',
     "https://github.com/torvalds/linux.git" : 'linux',
+    "git://git.hpdd.intel.com/fs/lustre-release.git" : 'lustre',
     "https://github.com/zfsonlinux/spl.git" : 'spl',
     "https://github.com/zfsonlinux/zfs.git" : 'zfs',
 }
@@ -68,6 +71,9 @@ def do_step_build(step, name):
 def do_step_build_linux(step):
     return do_step_build(step, 'buildlinux')
 
+def do_step_build_lustre(step):
+    return do_step_build(step, 'buildlustre')
+
 def do_step_build_spl(step):
     return do_step_build(step, 'buildspl')
 
@@ -101,7 +107,7 @@ style_factory.addStep(Git(repourl=zfs_repo, workdir="build/zfs",
 style_factory.addStep(ShellCommand(
     workdir="build/zfs", env={'PATH' : bin_path,
         'CONFIG_OPTIONS' : '--with-config=srpm'},
-    command=["runurl", bb_url + "bb-build-zfs.sh"],
+    command=["runurl", bb_url + "bb-build-intree.sh"],
     haltOnFailure=True, logEnviron=False,
     lazylogfiles=True,
     logfiles={"configure"  : { "filename" : "configure.log", "follow" : True },
@@ -154,7 +160,13 @@ build_factory.addStep(Git(repourl=zfs_repo, workdir="build/zfs",
     logEnviron=False, getDescription=True,
     lazylogfiles=True,
     description=["cloning"], descriptionDone=["cloned"]))
-
+build_factory.addStep(Git(repourl=lustre_repo, workdir="build/lustre",
+    mode="full", method="clobber", codebase="lustre",
+    logEnviron=False, getDescription=True,
+    lazylogfiles=True,
+    doStepIf = do_step_build_lustre,
+    hideStepIf=lambda results, s: results==SKIPPED,
+    description=["cloning"], descriptionDone=["cloned"]))
 build_factory.addStep(ShellCommand(
     workdir="build/linux", env={'PATH' : bin_path,
         'LINUX_BUILTIN' : util.Interpolate('%(prop:builtin:-no)s') },
@@ -172,7 +184,7 @@ build_factory.addStep(ShellCommand(
     workdir="build/spl", env={'PATH' : bin_path,
         'CONFIG_OPTIONS' : util.Interpolate('%(prop:configspl:-"")s'),
         'LINUX_CUSTOM' : util.Interpolate('%(prop:buildlinux:-no)s') },
-    command=["runurl", bb_url + "bb-build-zfs.sh"],
+    command=["runurl", bb_url + "bb-build-intree.sh"],
     haltOnFailure=True, logEnviron=False,
     lazylogfiles=True,
     logfiles={"configure"  : { "filename" : "configure.log", "follow" : True },
@@ -186,7 +198,7 @@ build_factory.addStep(ShellCommand(
     workdir="build/zfs", env={'PATH' : bin_path,
         'CONFIG_OPTIONS' : util.Interpolate('%(prop:configzfs:-"")s'),
         'LINUX_CUSTOM' : util.Interpolate('%(prop:buildlinux:-no)s') },
-    command=["runurl", bb_url + "bb-build-zfs.sh"],
+    command=["runurl", bb_url + "bb-build-intree.sh"],
     haltOnFailure=True, logEnviron=False,
     lazylogfiles=True,
     logfiles={"configure"  : { "filename" : "configure.log", "follow" : True },
@@ -203,6 +215,20 @@ build_factory.addStep(ShellCommand(command=["make", "lint"],
     decodeRC={0 : SUCCESS, 1 : FAILURE, 2 : WARNINGS, 3 : SKIPPED },
     description=["checking lint"], descriptionDone=["checked lint"],
     doStepIf = do_step_check_lint,
+    hideStepIf=lambda results, s: results==SKIPPED))
+build_factory.addStep(ShellCommand(
+    workdir="build/lustre", env={'PATH' : bin_path,
+        'CONFIG_OPTIONS' : util.Interpolate('%(prop:configlustre:-"")s'),
+        'LINUX_CUSTOM' : util.Interpolate('%(prop:buildlinux:-no)s') },
+    command=["runurl", bb_url + "bb-build-intree.sh"],
+    haltOnFailure=True, logEnviron=False,
+    lazylogfiles=True,
+    logfiles={"configure"  : { "filename" : "configure.log", "follow" : True },
+              "config.log" : { "filename" : "config.log",    "follow" : True },
+              "make"       : { "filename" : "make.log",      "follow" : True }},
+    decodeRC={0 : SUCCESS, 1 : FAILURE, 2 : WARNINGS, 3 : SKIPPED },
+    description=["building lustre"], descriptionDone=["built lustre"],
+    doStepIf = do_step_build_lustre,
     hideStepIf=lambda results, s: results==SKIPPED))
 
 #
@@ -462,9 +488,20 @@ style_slaves = [
     ) for i in range(0, numstyleslaves)
 ]
 
-# Distribution slaves
+# Build release slaves
 numslaves = 1
 
+centos7_x86_64_release_slave = [
+    ZFSEC2BuildSlave(
+        name="CentOS-7-x86_64-release-buildslave%s" % (str(i+1)),
+        ami="ami-4f27092f"
+    ) for i in range(0, numslaves)
+]
+
+release_slaves = \
+    centos7_x86_64_release_slave
+
+# Distribution slaves
 kernel_default_x86_64_slave = [
     ZFSEC2BuildSlave(
         name="Amazon-KernelDefault-x86_64-buildslave%s" % (str(i+1)),
@@ -681,6 +718,7 @@ perf_slaves = \
 # All slaves
 all_slaves = \
     style_slaves + \
+    release_slaves + \
     distro_slaves + \
     arch_slaves + \
     test_slaves + \
@@ -689,6 +727,7 @@ all_slaves = \
 style_tags = [ "Style" ]
 build_distro_tags = [ "Distributions" ]
 build_arch_tags = [ "Architectures" ]
+build_release_tags = [ "Release" ]
 test_tags = [ "Tests" ]
 perf_tags = [ "Performance" ]
 
@@ -707,7 +746,9 @@ builder_default_properties = {
     "buildlinux":    "no",
     "buildspl":      "yes",
     "buildzfs":      "yes",
+    "buildlustre":   "no",
     "builtin":       "no",
+    "configlustre":  "",
     "configspl":     "--enable-debug",
     "configzfs":     "--enable-debug",
     "repoowner":     "zfsonlinux",
@@ -715,11 +756,28 @@ builder_default_properties = {
     "checklint":     "no",
 }
 
-builder_redhat_properties = {
+builder_lustre_properties = {
     "buildlinux":    "no",
+    "buildlustre":   "yes",
     "buildspl":      "yes",
     "buildzfs":      "yes",
     "builtin":       "no",
+    "configlustre":  "--with-zfs --disable-ldiskfs",
+    "configspl":     "--with-spec=redhat",
+    "configzfs":     "--with-spec=redhat",
+    "repoowner":     "zfsonlinux",
+    "reponame":      "zfs",
+    "checklint":     "no",
+}
+
+
+builder_redhat_properties = {
+    "buildlinux":    "no",
+    "buildlustre":   "no",
+    "buildspl":      "yes",
+    "buildzfs":      "yes",
+    "builtin":       "no",
+    "configlustre":  "",
     "configspl":     "--enable-debug --with-spec=redhat",
     "configzfs":     "--enable-debug --with-spec=redhat",
     "repoowner":     "zfsonlinux",
@@ -729,9 +787,11 @@ builder_redhat_properties = {
 
 builder_release_properties = {
     "buildlinux":    "no",
+    "buildlustre":   "no",
     "buildspl":      "yes",
     "buildzfs":      "yes",
     "builtin":       "no",
+    "configlustre":  "",
     "configspl":     "",
     "configzfs":     "",
     "repoowner":     "zfsonlinux",
@@ -741,9 +801,11 @@ builder_release_properties = {
 
 builder_linux_properties = {
     "buildlinux":    "yes",
+    "buildlustre":   "no",
     "buildspl":      "yes",
     "buildzfs":      "yes",
     "builtin":       "no",
+    "configlustre":  "",
     "configspl":     "--enable-debug",
     "configzfs":     "--enable-debug",
     "repoowner":     "zfsonlinux",
@@ -753,9 +815,11 @@ builder_linux_properties = {
 
 builder_builtin_properties = {
     "buildlinux":    "yes",
+    "buildlustre":   "no",
     "buildspl":      "no",
     "buildzfs":      "no",
     "builtin":       "yes",
+    "configlustre":  "",
     "configspl":     "--enable-debug",
     "configzfs":     "--enable-debug",
     "repoowner":     "zfsonlinux",
@@ -765,9 +829,11 @@ builder_builtin_properties = {
 
 builder_style_properties = {
     "buildlinux":    "no",
+    "buildlustre":   "no",
     "buildspl":      "yes",
     "buildzfs":      "yes",
     "builtin":       "no",
+    "configlustre":  "",
     "configspl":     "--enable-debug",
     "configzfs":     "--enable-debug",
     "repoowner":     "zfsonlinux",
@@ -777,9 +843,11 @@ builder_style_properties = {
 
 builder_arch_properties = {
     "buildlinux":    "no",
+    "buildlustre":   "no",
     "buildspl":      "yes",
     "buildzfs":      "yes",
     "builtin":       "no",
+    "configlustre":  "",
     "configspl":     "--enable-debug",
     "configzfs":     "--enable-debug",
     "repoowner":     "zfsonlinux",
@@ -789,9 +857,11 @@ builder_arch_properties = {
 
 builder_perf_properties = {
     "buildlinux":    "no",
+    "buildlustre":   "no",
     "buildspl":      "yes",
     "buildzfs":      "yes",
     "builtin":       "no",
+    "configlustre":  "",
     "configspl":     "",
     "configzfs":     "",
     "repoowner":     "zfsonlinux",
@@ -857,6 +927,17 @@ style_builders = [
         slavenames=[slave.slavename for slave in style_slaves],
         tags=style_tags,
         properties=builder_style_properties,
+    ),
+]
+
+# Release builders
+release_builders = [
+    ZFSBuilderConfig(
+        name="CentOS 7 x86_64 Release (BUILD)",
+        factory=build_factory,
+        slavenames=[slave.name for slave in centos7_x86_64_release_slave],
+        tags=build_release_tags,
+        properties=builder_lustre_properties,
     ),
 ]
 
@@ -1056,6 +1137,7 @@ all_builders = \
     style_builders + \
     distro_builders + \
     arch_builders + \
+    release_builders + \
     test_builders + \
     perf_builders
 
@@ -1217,6 +1299,7 @@ from buildbot.changes import filter
 import copy
 
 style_builders = [builder.name for builder in style_builders]
+release_builders = [builder.name for builder in release_builders]
 distro_builders = [builder.name for builder in distro_builders]
 arch_builders = [builder.name for builder in arch_builders]
 test_builders = [builder.name for builder in test_builders]
@@ -1226,6 +1309,7 @@ c['schedulers'] = []
 
 default_codebases = {
     'linux' : {'repository': linux_repo, 'branch': 'master', 'revision': None},
+    'lustre': {'repository': lustre_repo, 'branch': 'b2_10', 'revision': None},
     'spl'   : {'repository': spl_repo, 'branch': 'master', 'revision': None},
     'zfs'   : {'repository': zfs_repo, 'branch': 'master', 'revision': None} }
 
@@ -1273,6 +1357,13 @@ c['schedulers'].append(CustomSingleBranchScheduler(
 
 # This scheduler is for pull requests.
 c['schedulers'].append(CustomSingleBranchScheduler(
+    name="pull-request-build-release-scheduler",
+    builderNames=release_builders,
+    codebases=default_codebases,
+    change_filter=filter.ChangeFilter(category_re=".*(build).*")))
+
+# This scheduler is for pull requests.
+c['schedulers'].append(CustomSingleBranchScheduler(
     name="pull-request-test-scheduler",
     builderNames=test_builders,
     codebases=default_codebases,
@@ -1288,7 +1379,8 @@ c['schedulers'].append(CustomSingleBranchScheduler(
 # This scheduler is for pushes to branches.
 c['schedulers'].append(SingleBranchScheduler(
     name="branch-scheduler",
-    builderNames=style_builders+distro_builders+arch_builders+test_builders,
+    builderNames=style_builders+distro_builders+arch_builders+
+        release_builders+test_builders,
     codebases=default_codebases,
     change_filter=filter.ChangeFilter(project_re=".*/zfs.*")))
 
@@ -1296,7 +1388,8 @@ c['schedulers'].append(SingleBranchScheduler(
 c['schedulers'].append(Try_Userpass(
     name="try-scheduler",
     port=bb_try_port,
-    builderNames=style_builders+distro_builders+arch_builders+test_builders,
+    builderNames=style_builders+distro_builders+arch_builders+
+        release_builders+test_builders,
     userpass=try_userpass))
 
 ####### STATUS TARGETS

--- a/scripts/bb-build-intree.sh
+++ b/scripts/bb-build-intree.sh
@@ -18,7 +18,7 @@ fi
 
 set -x
 
-./autogen.sh >>$CONFIG_LOG 2>&1 || exit 1
+sh ./autogen.sh >>$CONFIG_LOG 2>&1 || exit 1
 ./configure $CONFIG_OPTIONS $LINUX_OPTIONS >>$CONFIG_LOG 2>&1 || exit 1
 make $MAKE_OPTIONS >>$MAKE_LOG 2>&1 || exit 1
 


### PR DESCRIPTION
In order to ensure that we do not break lustre builds,
introduce build steps to the BUILD builders that build
the 2.10.51 tag of lustre.

NOTE: I need to do some more testing, currently lustre builds
are failing on build-dev. I'm submitting this to get eyes on it while
I confirm why lustre doesn't build.