### PR TITLE
Make BUILD builders obey build properties

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -170,6 +170,7 @@ build_factory.addStep(ShellCommand(
     hideStepIf=lambda results, s: results==SKIPPED))
 build_factory.addStep(ShellCommand(
     workdir="build/spl", env={'PATH' : bin_path,
+        'CONFIG_OPTIONS' : util.Interpolate('%(prop:configspl:-"")s'),
         'LINUX_CUSTOM' : util.Interpolate('%(prop:buildlinux:-no)s') },
     command=["runurl", bb_url + "bb-build-zfs.sh"],
     haltOnFailure=True, logEnviron=False,
@@ -183,6 +184,7 @@ build_factory.addStep(ShellCommand(
     hideStepIf=lambda results, s: results==SKIPPED))
 build_factory.addStep(ShellCommand(
     workdir="build/zfs", env={'PATH' : bin_path,
+        'CONFIG_OPTIONS' : util.Interpolate('%(prop:configzfs:-"")s'),
         'LINUX_CUSTOM' : util.Interpolate('%(prop:buildlinux:-no)s') },
     command=["runurl", bb_url + "bb-build-zfs.sh"],
     haltOnFailure=True, logEnviron=False,
@@ -227,7 +229,8 @@ test_factory.addStep(Git(repourl=spl_repo, workdir="build/spl",
     description=["cloning"], descriptionDone=["cloned"]))
 test_factory.addStep(ShellCommand(
     env={'PATH' : bin_path,
-        'CONFIG_OPTIONS' : util.Interpolate('%(prop:configspl:-"")s') },
+        'CONFIG_OPTIONS' : util.Interpolate('%(prop:configspl:-"")s'),
+        'LINUX_CUSTOM' : util.Interpolate('%(prop:buildlinux:-no)s') },
     workdir="build/spl",
     command=["runurl", bb_url + "bb-build-packages.sh"],
     haltOnFailure=True, logEnviron=False,
@@ -245,7 +248,8 @@ test_factory.addStep(Git(repourl=zfs_repo, workdir="build/zfs",
     description=["cloning"], descriptionDone=["cloned"]))
 test_factory.addStep(ShellCommand(
     env={'PATH' : bin_path,
-        'CONFIG_OPTIONS' : util.Interpolate('%(prop:configzfs:-"")s') },
+        'CONFIG_OPTIONS' : util.Interpolate('%(prop:configzfs:-"")s'),
+        'LINUX_CUSTOM' : util.Interpolate('%(prop:buildlinux:-no)s') },
     workdir="build/zfs",
     command=["runurl", bb_url + "bb-build-packages.sh"],
     haltOnFailure=True, logEnviron=False,


### PR DESCRIPTION
BUILD builders need to obey a build properties
assigned to them by buildbot. These builders were
running with default configure options set in the
bb-build-zfs.sh script.

Signed-off-by: Giuseppe Di Natale <dinatale2@llnl.gov>