### PR TITLE
Remove CentOS minor version from builder names

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -495,14 +495,14 @@ fedora26_x86_64_slave = [
 
 centos6_x86_64_slave = [
     ZFSEC2BuildSlave(
-        name="CentOS-6.7-x86_64-buildslave%s" % (str(i+1)),
+        name="CentOS-6-x86_64-buildslave%s" % (str(i+1)),
         ami="ami-ca2608aa"
     ) for i in range(0, numslaves)
 ]
 
 centos7_x86_64_slave = [
     ZFSEC2BuildSlave(
-        name="CentOS-7.1-x86_64-buildslave%s" % (str(i+1)),
+        name="CentOS-7-x86_64-buildslave%s" % (str(i+1)),
         ami="ami-4f27092f"
     ) for i in range(0, numslaves)
 ]
@@ -891,14 +891,14 @@ distro_builders = [
         properties=builder_default_properties,
     ),
     ZFSBuilderConfig(
-        name="CentOS 6.7 x86_64 (BUILD)",
+        name="CentOS 6 x86_64 (BUILD)",
         factory=build_factory,
         slavenames=[slave.name for slave in centos6_x86_64_slave],
         tags=build_distro_tags,
         properties=builder_redhat_properties,
     ),
     ZFSBuilderConfig(
-        name="CentOS 7.1 x86_64 (BUILD)",
+        name="CentOS 7 x86_64 (BUILD)",
         factory=build_factory,
         slavenames=[slave.name for slave in centos7_x86_64_slave],
         tags=build_distro_tags,
@@ -976,14 +976,14 @@ test_builders = [
         properties=builder_release_properties,
     ),
     ZFSBuilderConfig(
-        name="CentOS 6.7 x86_64 (TEST)",
+        name="CentOS 6 x86_64 (TEST)",
         factory=test_factory,
         slavenames=[slave.name for slave in centos6_x86_64_testslave],
         tags=test_tags,
         properties=builder_redhat_properties,
     ),
     ZFSBuilderConfig(
-        name="CentOS 7.1 x86_64 (TEST)",
+        name="CentOS 7 x86_64 (TEST)",
         factory=test_factory,
         slavenames=[slave.name for slave in centos7_x86_64_testslave],
         tags=test_tags,


### PR DESCRIPTION
Rename CentOS builders to only contain their major version
within the builder name. The AMIs for the CentOS builders
are constantly updated and are no longer 6.7 and 7.1.

Signed-off-by: Giuseppe Di Natale <dinatale2@llnl.gov>