### PR TITLE
Allow build property overrides in commit messages

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -6,6 +6,7 @@ from twisted.python import log
 from password import *
 from buildslaves import *
 from buildbot.buildslave import BuildSlave
+from buildbot.plugins import util
 
 bb_slave_port = 9989
 bb_try_port = 8033
@@ -63,6 +64,13 @@ from buildbot.status.results import SKIPPED
 
 def do_step_build(step, name):
     props = step.build.getProperties()
+    override_name = 'override-' + name
+    if props.hasProperty(override_name):
+        if props[override_name] == "yes":
+            return True
+        else:
+            return False
+
     if props.hasProperty(name) and props[name] == "yes":
         return True
     else:
@@ -82,6 +90,36 @@ def do_step_build_zfs(step):
 
 def do_step_check_lint(step):
     return do_step_build(step, 'checklint')
+
+def determine_prop(props, name, default):
+    override_name = 'override-' + name
+    if props.hasProperty(override_name):
+        return props[override_name]
+
+    if props.hasProperty(name):
+        return props[name]
+
+    return default
+
+@util.renderer
+def get_buildlinux(props):
+    return determine_prop(props, 'buildlinux', 'no')
+
+@util.renderer
+def get_builtin(props):
+    return determine_prop(props, 'builtin', 'no')
+
+@util.renderer
+def get_configlustre(props):
+    return determine_prop(props, 'configlustre', '')
+
+@util.renderer
+def get_configspl(props):
+    return determine_prop(props, 'configspl', '')
+
+@util.renderer
+def get_configzfs(props):
+    return determine_prop(props, 'configzfs', '')
 
 #
 # Build factory - Build source in-tree
@@ -142,7 +180,6 @@ build_factory.addStep(ShellCommand(
     lazylogfiles=True,
     description=["installing dependencies"],
     descriptionDone=["installed dependencies"]))
-
 build_factory.addStep(Git(repourl=linux_repo, workdir="build/linux",
     mode="full", method="clobber", shallow=True, codebase="linux",
     logEnviron=False, getDescription=True,
@@ -154,22 +191,26 @@ build_factory.addStep(Git(repourl=spl_repo, workdir="build/spl",
     mode="full", method="clobber", codebase="spl",
     logEnviron=False, getDescription=True,
     lazylogfiles=True,
-    description=["cloning"], descriptionDone=["cloned"]))
+    description=["cloning"], descriptionDone=["cloned"],
+    doStepIf = do_step_build_spl,
+    hideStepIf=lambda results, s: results==SKIPPED))
 build_factory.addStep(Git(repourl=zfs_repo, workdir="build/zfs",
     mode="full", method="clobber", codebase="zfs",
     logEnviron=False, getDescription=True,
     lazylogfiles=True,
-    description=["cloning"], descriptionDone=["cloned"]))
+    description=["cloning"], descriptionDone=["cloned"],
+    doStepIf = do_step_build_zfs,
+    hideStepIf=lambda results, s: results==SKIPPED))
 build_factory.addStep(Git(repourl=lustre_repo, workdir="build/lustre",
     mode="full", method="clobber", codebase="lustre",
     logEnviron=False, getDescription=True,
     lazylogfiles=True,
+    description=["cloning"], descriptionDone=["cloned"],
     doStepIf = do_step_build_lustre,
-    hideStepIf=lambda results, s: results==SKIPPED,
-    description=["cloning"], descriptionDone=["cloned"]))
+    hideStepIf=lambda results, s: results==SKIPPED))
 build_factory.addStep(ShellCommand(
     workdir="build/linux", env={'PATH' : bin_path,
-        'LINUX_BUILTIN' : util.Interpolate('%(prop:builtin:-no)s') },
+        'LINUX_BUILTIN' : util.Interpolate('%(kw:p)s', p=get_builtin) },
     command=["runurl", bb_url + "bb-build-linux.sh"],
     haltOnFailure=True, logEnviron=False,
     lazylogfiles=True,
@@ -182,8 +223,8 @@ build_factory.addStep(ShellCommand(
     hideStepIf=lambda results, s: results==SKIPPED))
 build_factory.addStep(ShellCommand(
     workdir="build/spl", env={'PATH' : bin_path,
-        'CONFIG_OPTIONS' : util.Interpolate('%(prop:configspl:-"")s'),
-        'LINUX_CUSTOM' : util.Interpolate('%(prop:buildlinux:-no)s') },
+        'CONFIG_OPTIONS' : util.Interpolate('%(kw:p)s', p=get_configspl),
+        'LINUX_CUSTOM' : util.Interpolate('%(kw:p)s', p=get_buildlinux) },
     command=["runurl", bb_url + "bb-build-intree.sh"],
     haltOnFailure=True, logEnviron=False,
     lazylogfiles=True,
@@ -196,8 +237,8 @@ build_factory.addStep(ShellCommand(
     hideStepIf=lambda results, s: results==SKIPPED))
 build_factory.addStep(ShellCommand(
     workdir="build/zfs", env={'PATH' : bin_path,
-        'CONFIG_OPTIONS' : util.Interpolate('%(prop:configzfs:-"")s'),
-        'LINUX_CUSTOM' : util.Interpolate('%(prop:buildlinux:-no)s') },
+        'CONFIG_OPTIONS' : util.Interpolate('%(kw:p)s', p=get_configzfs),
+        'LINUX_CUSTOM' : util.Interpolate('%(kw:p)s', p=get_buildlinux) },
     command=["runurl", bb_url + "bb-build-intree.sh"],
     haltOnFailure=True, logEnviron=False,
     lazylogfiles=True,
@@ -252,11 +293,13 @@ test_factory.addStep(Git(repourl=spl_repo, workdir="build/spl",
     mode="full", method="clobber", codebase="spl",
     logEnviron=False, getDescription=True,
     lazylogfiles=True,
-    description=["cloning"], descriptionDone=["cloned"]))
+    description=["cloning"], descriptionDone=["cloned"],
+    doStepIf = do_step_build_spl,
+    hideStepIf=lambda results, s: results==SKIPPED))
 test_factory.addStep(ShellCommand(
     env={'PATH' : bin_path,
-        'CONFIG_OPTIONS' : util.Interpolate('%(prop:configspl:-"")s'),
-        'LINUX_CUSTOM' : util.Interpolate('%(prop:buildlinux:-no)s') },
+        'CONFIG_OPTIONS' : util.Interpolate('%(kw:p)s', p=get_configspl),
+        'LINUX_CUSTOM' : util.Interpolate('%(kw:p)s', p=get_buildlinux) },
     workdir="build/spl",
     command=["runurl", bb_url + "bb-build-packages.sh"],
     haltOnFailure=True, logEnviron=False,
@@ -266,16 +309,20 @@ test_factory.addStep(ShellCommand(
               "make"       : { "filename" : "make.log",      "follow" : True },
               "install"    : { "filename" : "install.log",   "follow" : True }},
     decodeRC={0 : SUCCESS, 1 : FAILURE, 2 : WARNINGS, 3 : SKIPPED },
-    description=["building spl"], descriptionDone=["built spl"]))
+    description=["building spl"], descriptionDone=["built spl"],
+    doStepIf = do_step_build_spl,
+    hideStepIf=lambda results, s: results==SKIPPED))
 test_factory.addStep(Git(repourl=zfs_repo, workdir="build/zfs",
     mode="full", method="clobber", codebase="zfs",
     logEnviron=False, getDescription=True,
     lazylogfiles=True,
-    description=["cloning"], descriptionDone=["cloned"]))
+    description=["cloning"], descriptionDone=["cloned"],
+    doStepIf = do_step_build_zfs,
+    hideStepIf=lambda results, s: results==SKIPPED))
 test_factory.addStep(ShellCommand(
     env={'PATH' : bin_path,
-        'CONFIG_OPTIONS' : util.Interpolate('%(prop:configzfs:-"")s'),
-        'LINUX_CUSTOM' : util.Interpolate('%(prop:buildlinux:-no)s') },
+        'CONFIG_OPTIONS' : util.Interpolate('%(kw:p)s', p=get_configzfs),
+        'LINUX_CUSTOM' : util.Interpolate('%(kw:p)s', p=get_buildlinux) },
     workdir="build/zfs",
     command=["runurl", bb_url + "bb-build-packages.sh"],
     haltOnFailure=True, logEnviron=False,
@@ -285,7 +332,9 @@ test_factory.addStep(ShellCommand(
               "make"       : { "filename" : "make.log",      "follow" : True },
               "install"    : { "filename" : "install.log",   "follow" : True }},
     decodeRC={0 : SUCCESS, 1 : FAILURE, 2 : WARNINGS, 3 : SKIPPED },
-    description=["building zfs"], descriptionDone=["built zfs"]))
+    description=["building zfs"], descriptionDone=["built zfs"],
+    doStepIf = do_step_build_zfs,
+    hideStepIf=lambda results, s: results==SKIPPED))
 test_factory.addStep(ShellCommand(
     workdir="build/tests",
     env={'PATH' : bin_path + ":" + zfs_path},
@@ -365,13 +414,22 @@ test_factory.addStep(ShellCommand(
     decodeRC={0 : SUCCESS, 1 : FAILURE, 2 : WARNINGS, 3 : SKIPPED },
     description=["zfsstress"], descriptionDone=["zfsstress"],
     hideStepIf=lambda results, s: results==SKIPPED))
-
 test_factory.addStep(ShellCommand(command=["runurl", bb_url + "bb-cleanup.sh"],
-    env={'PATH' : bin_path},
+    env={'PATH' : bin_path, 'BUILT_PACKAGE' : 'zfs'},
     haltOnFailure=False, logEnviron=False,
     lazylogfiles=True,
     decodeRC={0 : SUCCESS, 1 : FAILURE, 2 : WARNINGS, 3 : SKIPPED },
-    description=["removing zfs"], descriptionDone=["removed zfs"]))
+    description=["removing zfs"], descriptionDone=["removed zfs"],
+    doStepIf = do_step_build_zfs,
+    hideStepIf=lambda results, s: results==SKIPPED))
+test_factory.addStep(ShellCommand(command=["runurl", bb_url + "bb-cleanup.sh"],
+    env={'PATH' : bin_path, 'BUILT_PACKAGE' : 'spl'},
+    haltOnFailure=False, logEnviron=False,
+    lazylogfiles=True,
+    decodeRC={0 : SUCCESS, 1 : FAILURE, 2 : WARNINGS, 3 : SKIPPED },
+    description=["removing spl"], descriptionDone=["removed spl"],
+    doStepIf = do_step_build_spl,
+    hideStepIf=lambda results, s: results==SKIPPED))
 
 #
 # Performance factory - Build packages and run the performance suite.
@@ -395,10 +453,12 @@ perf_factory.addStep(Git(repourl=spl_repo, workdir="build/spl",
     mode="full", method="clobber", codebase="spl",
     logEnviron=False, getDescription=True,
     lazylogfiles=True,
-    description=["cloning"], descriptionDone=["cloned"]))
+    description=["cloning"], descriptionDone=["cloned"],
+    doStepIf = do_step_build_spl,
+    hideStepIf=lambda results, s: results==SKIPPED))
 perf_factory.addStep(ShellCommand(
     env={'PATH' : bin_path,
-        'CONFIG_OPTIONS' : util.Interpolate('%(prop:configspl:-"")s') },
+        'CONFIG_OPTIONS' : util.Interpolate('%(kw:p)s', p=get_configspl) },
     workdir="build/spl",
     command=["runurl", bb_url + "bb-build-packages.sh"],
     haltOnFailure=True, logEnviron=False,
@@ -408,15 +468,19 @@ perf_factory.addStep(ShellCommand(
               "make"       : { "filename" : "make.log",      "follow" : True },
               "install"    : { "filename" : "install.log",   "follow" : True }},
     decodeRC={0 : SUCCESS, 1 : FAILURE, 2 : WARNINGS, 3 : SKIPPED },
-    description=["building spl"], descriptionDone=["built spl"]))
+    description=["building spl"], descriptionDone=["built spl"],
+    doStepIf = do_step_build_spl,
+    hideStepIf=lambda results, s: results==SKIPPED))
 perf_factory.addStep(Git(repourl=zfs_repo, workdir="build/zfs",
     mode="full", method="clobber", codebase="zfs",
     logEnviron=False, getDescription=True,
     lazylogfiles=True,
-    description=["cloning"], descriptionDone=["cloned"]))
+    description=["cloning"], descriptionDone=["cloned"],
+    doStepIf = do_step_build_zfs,
+    hideStepIf=lambda results, s: results==SKIPPED))
 perf_factory.addStep(ShellCommand(
     env={'PATH' : bin_path,
-        'CONFIG_OPTIONS' : util.Interpolate('%(prop:configzfs:-"")s') },
+        'CONFIG_OPTIONS' : util.Interpolate('%(kw:p)s', p=get_configzfs) },
     workdir="build/zfs",
     command=["runurl", bb_url + "bb-build-packages.sh"],
     haltOnFailure=True, logEnviron=False,
@@ -426,7 +490,9 @@ perf_factory.addStep(ShellCommand(
               "make"       : { "filename" : "make.log",      "follow" : True },
               "install"    : { "filename" : "install.log",   "follow" : True }},
     decodeRC={0 : SUCCESS, 1 : FAILURE, 2 : WARNINGS, 3 : SKIPPED },
-    description=["building zfs"], descriptionDone=["built zfs"]))
+    description=["building zfs"], descriptionDone=["built zfs"],
+    doStepIf = do_step_build_zfs,
+    hideStepIf=lambda results, s: results==SKIPPED))
 perf_factory.addStep(ShellCommand(
     workdir="build/tests",
     env={'PATH' : bin_path + ":" + zfs_path,
@@ -1186,6 +1252,18 @@ def parse_link_header(link_header):
     return links
 
 class CustomGitHubEventHandler(GitHubEventHandler):
+    valid_props = [
+        ('^Build[-\s]linux:\s*(yes|no)\s*$', 'override-buildlinux'),
+        ('^Build[-\s]lustre:\s*(yes|no)\s*$', 'override-buildlustre'),
+        ('^Build[-\s]spl:\s*(yes|no)\s*$', 'override-buildspl'),
+        ('^Build[-\s]zfs:\s*(yes|no)\s*$', 'override-buildzfs'),
+        ('^Built[-\s]in:\s*(yes|no)\s*$', 'override-builtin'),
+        ('^Check[-\s]lint:\s*(yes|no)\s*$', 'override-checklint'),
+        ('^Configure[-|\s]lustre:(.*)$', 'override-configlustre'),
+        ('^Configure[-|\s]spl:(.*)$', 'override-configspl'),
+        ('^Configure[-|\s]zfs:(.*)$', 'override-configzfs'),
+    ]
+
     def handle_pull_request(self, payload):
         changes = []
         number = payload['number']
@@ -1230,6 +1308,15 @@ class CustomGitHubEventHandler(GitHubEventHandler):
             else:
                 category = "style,build"
 
+            # Extract if the commit message has property overrides
+            properties = {}
+            for prop in CustomGitHubEventHandler.valid_props:
+                step_pattern = prop[0]
+                m = re.search(step_pattern, comments, re.I | re.M)
+                if m is not None:
+                    prop_name = prop[1]
+                    properties[prop_name] = m.group(1).lower()
+
             # Extract any overrides for builders for this commit
             # Requires-builders: style build arch distro test perf none
             category_pattern = '^Requires-builders:\s*([ ,a-zA-Z0-9]+)'
@@ -1265,6 +1352,7 @@ class CustomGitHubEventHandler(GitHubEventHandler):
                 'revlink' : commit['html_url'],
                 'repository': payload['repository']['clone_url'],
                 'project' : payload['repository']['name'],
+                'properties' : properties,
                 'category': category,
                 'author': "%s <%s>" % (commit['commit']['committer']['name'],
                                        commit['commit']['committer']['email']),

--- a/scripts/bb-build-linux.sh
+++ b/scripts/bb-build-linux.sh
@@ -29,17 +29,29 @@ if test "$LINUX_BUILTIN" = "yes"; then
 
     set -x
     make prepare scripts >>$CONFIG_LOG 2>&1 || exit 1
-    cd ../spl >>$CONFIG_LOG 2>&1 || exit 1
-    sh ./autogen.sh >>$CONFIG_LOG 2>&1 || exit 1
-    ./configure $CONFIG_OPTIONS $LINUX_OPTIONS >>$CONFIG_LOG 2>&1 || exit 1
-    ./copy-builtin $LINUX_DIR >>$CONFIG_LOG 2>&1 || exit 1
-    cd ../zfs >>$CONFIG_LOG 2>&1 || exit 1
-    sh ./autogen.sh >>$CONFIG_LOG 2>&1 || exit 1
-    ./configure $CONFIG_OPTIONS $LINUX_OPTIONS >>$CONFIG_LOG 2>&1 || exit 1
-    ./copy-builtin $LINUX_DIR >>$CONFIG_LOG 2>&1 || exit 1
+
+    if [ -d "../spl" ]; then
+        cd ../spl >>$CONFIG_LOG 2>&1 || exit 1
+        sh ./autogen.sh >>$CONFIG_LOG 2>&1 || exit 1
+        ./configure $CONFIG_OPTIONS $LINUX_OPTIONS >>$CONFIG_LOG 2>&1 || exit 1
+        ./copy-builtin $LINUX_DIR >>$CONFIG_LOG 2>&1 || exit 1
+    fi
+
+    if [ -d "../zfs" ]; then
+        cd ../zfs >>$CONFIG_LOG 2>&1 || exit 1
+        sh ./autogen.sh >>$CONFIG_LOG 2>&1 || exit 1
+        ./configure $CONFIG_OPTIONS $LINUX_OPTIONS >>$CONFIG_LOG 2>&1 || exit 1
+        ./copy-builtin $LINUX_DIR >>$CONFIG_LOG 2>&1 || exit 1
+    fi
+
     cd ../linux >>$CONFIG_LOG 2>&1 || exit 1
-    echo "CONFIG_SPL=y" >>$CONFIG_FILE
-    echo "CONFIG_ZFS=y" >>$CONFIG_FILE
+    if [ -d "../spl" ]; then
+      echo "CONFIG_SPL=y" >>$CONFIG_FILE
+    fi
+
+    if [ -d "../zfs" ]; then
+        echo "CONFIG_ZFS=y" >>$CONFIG_FILE
+    fi
 fi
 
 set -x

--- a/scripts/bb-cleanup.sh
+++ b/scripts/bb-cleanup.sh
@@ -9,66 +9,109 @@ else
 fi
 
 SUDO="sudo -E"
+BUILT_PACKAGE=${BUILT_PACKAGE:-""}
 
 set -x
 
 case "$BB_NAME" in
 Amazon*)
-    $SUDO yum -y remove \
-        kmod-zfs-$(uname -r) kmod-zfs-devel-$(uname -r) \
-        kmod-spl-$(uname -r) kmod-spl-devel-$(uname -r) \
-        libnvpair1 libuutil1 libzfs2 libzpool2 libzfs2-devel \
-        zfs zfs-debuginfo zfs-kmod-debuginfo zfs-dracut  zfs-test \
-        spl spl-debuginfo spl-kmod-debuginfo
+    if test "$BUILT_PACKAGE" = "zfs"; then
+        $SUDO yum -y remove \
+            kmod-zfs-$(uname -r) kmod-zfs-devel-$(uname -r) \
+            libnvpair1 libuutil1 libzfs2 libzpool2 libzfs2-devel \
+            zfs zfs-debuginfo zfs-kmod-debuginfo zfs-dracut  zfs-test
+    fi
+
+    if test "$BUILT_PACKAGE" = "spl"; then
+        $SUDO yum -y remove \
+            kmod-spl-$(uname -r) kmod-spl-devel-$(uname -r) \
+            spl spl-debuginfo spl-kmod-debuginfo
+    fi
     ;;
 
 CentOS*)
-    $SUDO yum -y remove \
-        kmod-zfs-$(uname -r) kmod-zfs-devel-$(uname -r) \
-        kmod-spl-$(uname -r) kmod-spl-devel-$(uname -r) \
-        libnvpair1 libuutil1 libzfs2 libzpool2 libzfs2-devel \
-        zfs zfs-debuginfo zfs-kmod-debuginfo zfs-dracut  zfs-test \
-        spl spl-debuginfo spl-kmod-debuginfo
+    if test "$BUILT_PACKAGE" = "zfs"; then
+        $SUDO yum -y remove \
+            kmod-zfs kmod-zfs-devel \
+            libnvpair1 libuutil1 libzfs2 libzpool2 libzfs2-devel \
+            zfs zfs-debuginfo zfs-kmod-debuginfo zfs-dracut zfs-test
+    fi
+
+    if test "$BUILT_PACKAGE" = "spl"; then
+        $SUDO yum -y remove \
+            kmod-spl-$(uname -r) kmod-spl-devel-$(uname -r) \
+            spl spl-debuginfo spl-kmod-debuginfo
+    fi
     ;;
 
 Debian*)
-    $SUDO apt-get --yes purge \
-        kmod-zfs-$(uname -r) kmod-zfs-devel-$(uname -r) \
-        kmod-spl-$(uname -r) kmod-spl-devel-$(uname -r) \
-        libnvpair1 libuutil1 libzfs2 libzpool2 libzfs2-devel \
-        zfs zfs-initramfs zfs-dracut zfs-test spl
+    if test "$BUILT_PACKAGE" = "zfs"; then
+        $SUDO apt-get --yes purge \
+            kmod-zfs-$(uname -r) kmod-zfs-devel-$(uname -r) \
+            libnvpair1 libuutil1 libzfs2 libzpool2 libzfs2-devel \
+            zfs zfs-initramfs zfs-dracut zfs-test
+    fi
+
+    if test "$BUILT_PACKAGE" = "spl"; then
+        $SUDO apt-get --yes purge \
+            kmod-spl-$(uname -r) kmod-spl-devel-$(uname -r) spl
+    fi
     ;;
 
 Fedora*)
-    $SUDO dnf -y remove \
-        kmod-zfs-$(uname -r) kmod-zfs-devel-$(uname -r) \
-        kmod-spl-$(uname -r) kmod-spl-devel-$(uname -r) \
-        libnvpair1 libuutil1 libzfs2 libzpool2 libzfs2-devel \
-        zfs zfs-debuginfo zfs-kmod-debuginfo zfs-dracut  zfs-test \
-        spl spl-debuginfo spl-kmod-debuginfo
+    if test "$BUILT_PACKAGE" = "zfs"; then
+        $SUDO dnf -y remove \
+            kmod-zfs-$(uname -r) kmod-zfs-devel-$(uname -r) \
+            libnvpair1 libuutil1 libzfs2 libzpool2 libzfs2-devel \
+            zfs zfs-debuginfo zfs-kmod-debuginfo zfs-dracut zfs-test
+    fi
+
+    if test "$BUILT_PACKAGE" = "spl"; then
+        $SUDO dnf -y remove \
+            kmod-spl-$(uname -r) kmod-spl-devel-$(uname -r) \
+            spl spl-debuginfo spl-kmod-debuginfo
+    fi
     ;;
 
 RHEL*)
-    $SUDO yum -y remove \
-        kmod-zfs-$(uname -r) kmod-zfs-devel-$(uname -r) \
-        kmod-spl-$(uname -r) kmod-spl-devel-$(uname -r) \
-        libnvpair1 libuutil1 libzfs2 libzpool2 libzfs2-devel \
-        zfs zfs-debuginfo zfs-kmod-debuginfo zfs-dracut  zfs-test \
-        spl spl-debuginfo spl-kmod-debuginfo
+    if test "$BUILT_PACKAGE" = "zfs"; then
+        $SUDO yum -y remove \
+            kmod-zfs kmod-zfs-devel \
+            libnvpair1 libuutil1 libzfs2 libzpool2 libzfs2-devel \
+            zfs zfs-debuginfo zfs-kmod-debuginfo zfs-dracut zfs-test
+    fi
+
+    if test "$BUILT_PACKAGE" = "spl"; then
+        $SUDO yum -y remove \
+            kmod-spl-$(uname -r) kmod-spl-devel-$(uname -r) \
+            spl spl-debuginfo spl-kmod-debuginfo
+    fi
     ;;
 
 SUSE*)
-    $SUDO zypper --non-interactive remove \
-        libnvpair1 libuutil1 libzfs2 libzpool2 libzfs2-devel \
-        zfs zfs-dracut  zfs-test spl
+    if test "$BUILT_PACKAGE" = "zfs"; then
+        $SUDO zypper --non-interactive remove \
+            libnvpair1 libuutil1 libzfs2 libzpool2 libzfs2-devel \
+            zfs zfs-dracut zfs-test
+    fi
+
+    if test "$BUILT_PACKAGE" = "spl"; then
+        $SUDO zypper --non-interactive remove spl
+    fi
     ;;
 
 Ubuntu*)
-    $SUDO apt-get --yes purge \
-        kmod-zfs-$(uname -r) kmod-zfs-devel-$(uname -r) \
-        kmod-spl-$(uname -r) kmod-spl-devel-$(uname -r) \
-        libnvpair1 libuutil1 libzfs2 libzpool2 libzfs2-devel \
-        zfs zfs-initramfs zfs-dracut zfs-test spl
+    if test "$BUILT_PACKAGE" = "zfs"; then
+        $SUDO apt-get --yes purge \
+            kmod-zfs-$(uname -r) kmod-zfs-devel-$(uname -r) \
+            libnvpair1 libuutil1 libzfs2 libzpool2 libzfs2-devel \
+            zfs zfs-initramfs zfs-dracut zfs-test
+    fi
+
+    if test "$BUILT_PACKAGE" = "spl"; then
+        $SUDO apt-get --yes purge \
+            kmod-spl-$(uname -r) kmod-spl-devel-$(uname -r) spl
+    fi
     ;;
 
 *)


### PR DESCRIPTION
Allow for users to control if and how zfs, spl, and lustre are
built in commit messages. If an override is provided, they will
replace the builder specified defaults.

Signed-off-by: Giuseppe Di Natale <dinatale2@llnl.gov>