### PR TITLE
Automatically choose spl branch to build

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -1345,6 +1345,8 @@ class CustomGitHubEventHandler(GitHubEventHandler):
             comments = comments + "Pull-request: #%d part %d/%d\n" % (
                 number, commits_cur, commits_num)
 
+            properties['base_branch'] = payload['pull_request']['base']['ref']
+
             change = {
                 'revision' : commit['sha'],
                 'when_timestamp': created_at,
@@ -1403,6 +1405,7 @@ default_codebases = {
 
 class CustomSingleBranchScheduler(SingleBranchScheduler):
     spl_pull_request = None
+    zfs_branch = None
 
     def gotChange(self, change, important):
         pattern = '^Requires-spl:\s*([a-zA-Z0-9_\-\:\/\+]+)'
@@ -1412,6 +1415,11 @@ class CustomSingleBranchScheduler(SingleBranchScheduler):
         else:
             self.spl_pull_request = None
 
+        if 'base_branch' in change.properties:
+            self.zfs_branch = change.properties['base_branch']
+        else:
+            self.zfs_branch = change.branch
+
         return SingleBranchScheduler.gotChange(self, change, important)
 
     def getCodebaseDict(self, codebase):
@@ -1419,6 +1427,11 @@ class CustomSingleBranchScheduler(SingleBranchScheduler):
         if codebase == "spl":
             if self.spl_pull_request is not None:
                 ss['branch'] = self.spl_pull_request
+            elif self.zfs_branch is not None:
+                branch_pattern = 'zfs-(.+)'
+                m = re.search(branch_pattern, self.zfs_branch, re.I | re.M)
+                if m is not None:
+                    ss['branch'] = 'spl-%s' % (m.group(1))
 
         return ss
 


### PR DESCRIPTION
Determine which zfs branch a pull request or merge is occuring
against and allow buildbot to clone the correct spl branch for
testing.

Signed-off-by: Giuseppe Di Natale <dinatale2@llnl.gov>