### PR TITLE
Re-enable Lustre build step

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -824,7 +824,7 @@ builder_default_properties = {
 
 builder_lustre_properties = {
     "buildlinux":    "no",
-    "buildlustre":   "no",
+    "buildlustre":   "yes",
     "buildspl":      "yes",
     "buildzfs":      "yes",
     "builtin":       "no",


### PR DESCRIPTION
LU-9890 has landed in Lustre's b2_10 branch. That change
allows Lustre to handle the interface changes in
dmu_objset_own and dmu_objset_disown allowing it to
build against the master branch of ZFS.

Signed-off-by: Giuseppe Di Natale <dinatale2@llnl.gov>