### PR TITLE
Force EC2 instances to shutdown after 10 hours

### DIFF
--- a/scripts/bb-bootstrap.sh
+++ b/scripts/bb-bootstrap.sh
@@ -365,6 +365,7 @@ if test "$BB_MODE" = "BUILD" -o "$BB_MODE" = "STYLE"; then
     $SUDO -u buildbot $BUILDSLAVE start $BB_DIR
 else
     echo "@reboot $SUDO -u buildbot $BUILDSLAVE start $BB_DIR" | crontab
+    echo "@reboot shutdown +480" | crontab
     crontab -l
     $SUDO reboot
 fi


### PR DESCRIPTION
We have cases of EC2 instances being stranded by buildbot.
Introduce a timed shutdown so TEST slaves don't persist
for large amounts of time.

Signed-off-by: Giuseppe Di Natale <dinatale2@llnl.gov>