### PR TITLE
Force EC2 instances to shutdown after 8 hours

### DIFF
--- a/scripts/bb-test-prepare.sh
+++ b/scripts/bb-test-prepare.sh
@@ -219,4 +219,16 @@ case "$BB_NAME" in
         ;;
 esac
 
+# Schedule a shutdown for all distros other than CentOS 6, Ubuntu 14.04,
+# and Amazon based distros
+case "$BB_NAME" in
+    Amazon*|CentOS-6*|Ubuntu-14.04*)
+        echo "Skipping scheduled shutdown"
+        ;;
+    *)
+        echo "Scheduling shutdown"
+        sudo -E shutdown +480
+        ;;
+esac
+
 exit 0


### PR DESCRIPTION
We have cases of EC2 instances being stranded by buildbot.
Introduce a timed shutdown so TEST slaves don't persist
for large amounts of time.

Signed-off-by: Giuseppe Di Natale <dinatale2@llnl.gov>