### PR TITLE
Install mandoc as a dependency on STYLE builder

### DIFF
--- a/scripts/bb-dependencies.sh
+++ b/scripts/bb-dependencies.sh
@@ -138,7 +138,7 @@ Ubuntu*)
         libssl-dev
 
     if test "$BB_MODE" = "STYLE"; then
-        $SUDO apt-get --yes install pax-utils shellcheck cppcheck
+        $SUDO apt-get --yes install pax-utils shellcheck cppcheck mandoc
         $SUDO pip --quiet install flake8
     fi
     ;;


### PR DESCRIPTION
mandoc is required for linting purposes on the STYLE builder.

Signed-off-by: Giuseppe Di Natale <dinatale2@llnl.gov>