### PR TITLE
STYLE Builder should boot Ubuntu 17.04 AMI

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -550,7 +550,7 @@ numstyleslaves = 2
 style_slaves = [
     ZFSEC2StyleSlave(
         name="Ubuntu-17.10-x86_64-styleslave%s" % (str(i+1)),
-        ami="ami-1b29077b"
+        ami="ami-dc6254bc"
     ) for i in range(0, numstyleslaves)
 ]
 


### PR DESCRIPTION
Correct STYLE builder AMI.

Signed-off-by: Giuseppe Di Natale <dinatale2@llnl.gov>