### PR TITLE
Fix /etc/buildslave dependency

### DIFF
--- a/scripts/bb-build.sh
+++ b/scripts/bb-build.sh
@@ -1,11 +1,7 @@
 #!/bin/sh
 
-# Check for a local cached configuration.
 if test -f /etc/buildslave; then
 	. /etc/buildslave
-else
-	echo "Missing configuration /etc/buildslave"
-	exit 1
 fi
 
 LINUX_OPTIONS=${LINUX_OPTIONS:-""}


### PR DESCRIPTION
The /etc/buildslave file is not mandatory and won't exist on
builders which weren't bootstrapped by ec2.  This is fine since
BB_NAME is only used during install which won't happen on
normal BUILD slaves.
