### PR TITLE
Clone repos before builds on TEST builders

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -304,6 +304,13 @@ test_factory.addStep(Git(repourl=spl_repo, workdir="build/spl",
     description=["cloning"], descriptionDone=["cloned"],
     doStepIf = do_step_build_spl,
     hideStepIf=lambda results, s: results==SKIPPED))
+test_factory.addStep(Git(repourl=zfs_repo, workdir="build/zfs",
+    mode="full", method="clobber", codebase="zfs",
+    logEnviron=False, getDescription=True,
+    lazylogfiles=True,
+    description=["cloning"], descriptionDone=["cloned"],
+    doStepIf = do_step_build_zfs,
+    hideStepIf=lambda results, s: results==SKIPPED))
 test_factory.addStep(ShellCommand(
     env={'PATH' : bin_path,
         'CONFIG_OPTIONS' : util.Interpolate('%(kw:p)s', p=get_configspl),
@@ -320,13 +327,6 @@ test_factory.addStep(ShellCommand(
     decodeRC={0 : SUCCESS, 1 : FAILURE, 2 : WARNINGS, 3 : SKIPPED },
     description=["building spl"], descriptionDone=["built spl"],
     doStepIf = do_step_build_spl,
-    hideStepIf=lambda results, s: results==SKIPPED))
-test_factory.addStep(Git(repourl=zfs_repo, workdir="build/zfs",
-    mode="full", method="clobber", codebase="zfs",
-    logEnviron=False, getDescription=True,
-    lazylogfiles=True,
-    description=["cloning"], descriptionDone=["cloned"],
-    doStepIf = do_step_build_zfs,
     hideStepIf=lambda results, s: results==SKIPPED))
 test_factory.addStep(ShellCommand(
     env={'PATH' : bin_path,
@@ -482,6 +482,13 @@ perf_factory.addStep(Git(repourl=spl_repo, workdir="build/spl",
     description=["cloning"], descriptionDone=["cloned"],
     doStepIf = do_step_build_spl,
     hideStepIf=lambda results, s: results==SKIPPED))
+perf_factory.addStep(Git(repourl=zfs_repo, workdir="build/zfs",
+    mode="full", method="clobber", codebase="zfs",
+    logEnviron=False, getDescription=True,
+    lazylogfiles=True,
+    description=["cloning"], descriptionDone=["cloned"],
+    doStepIf = do_step_build_zfs,
+    hideStepIf=lambda results, s: results==SKIPPED))
 perf_factory.addStep(ShellCommand(
     env={'PATH' : bin_path,
         'CONFIG_OPTIONS' : util.Interpolate('%(kw:p)s', p=get_configspl),
@@ -497,13 +504,6 @@ perf_factory.addStep(ShellCommand(
     decodeRC={0 : SUCCESS, 1 : FAILURE, 2 : WARNINGS, 3 : SKIPPED },
     description=["building spl"], descriptionDone=["built spl"],
     doStepIf = do_step_build_spl,
-    hideStepIf=lambda results, s: results==SKIPPED))
-perf_factory.addStep(Git(repourl=zfs_repo, workdir="build/zfs",
-    mode="full", method="clobber", codebase="zfs",
-    logEnviron=False, getDescription=True,
-    lazylogfiles=True,
-    description=["cloning"], descriptionDone=["cloned"],
-    doStepIf = do_step_build_zfs,
     hideStepIf=lambda results, s: results==SKIPPED))
 perf_factory.addStep(ShellCommand(
     env={'PATH' : bin_path,


### PR DESCRIPTION
Clone all repos necessary for building before
building and testing on TEST builders. This will
avoid TEST builders from doing work if a stale
commit is present.

Signed-off-by: Giuseppe Di Natale <dinatale2@llnl.gov>