### PR TITLE
CustomSingleBranchScheduler for branch scheduler

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -1547,7 +1547,7 @@ c['schedulers'].append(CustomSingleBranchScheduler(
     change_filter=filter.ChangeFilter(category_re=".*perf.*")))
 
 # This scheduler is for pushes to branches.
-c['schedulers'].append(SingleBranchScheduler(
+c['schedulers'].append(CustomSingleBranchScheduler(
     name="branch-scheduler",
     builderNames=style_builders+distro_builders+arch_builders+
         release_builders+test_builders,


### PR DESCRIPTION
Use the CustomSingleBranchSchduler when scheduling changes
committed to branches.

Signed-off-by: Giuseppe Di Natale <dinatale2@llnl.gov>