### PR TITLE
codecov: use make targets to generate code coverage reports

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -876,7 +876,7 @@ builder_coverage_properties = {
     "builtin":       "no",
     "configlustre":  "",
     "configspl":     "--enable-debug",
-    "configzfs":     "--enable-debug --enable-debuginfo --enable-gcov",
+    "configzfs":     "--enable-debug --enable-debuginfo --enable-code-coverage",
     "install":       "in-tree",
     "repoowner":     "zfsonlinux",
     "reponame":      "zfs",


### PR DESCRIPTION
This updates the buildbot infrastructure to do the following:

 - Use the "--enable-code-coverage" configuration option for enabling
   the code coverage compiler flags, rather than "--enable-gcov"

 - Updates the script that interfaces with codecov.io to use the new
   make targets that are available when using "--enable-code-coverage".
   This enables us to capture code coverage information for our
   userspace libraries (e.g. libzpool), as this works "out of the box"
   when using these make targets.

 - Uploads two different reports to codecov.io for each test run; one
   report covers the user-mode execution (e.g. commands, libzpool, etc),
   and a seperate report that covers the kernel-mode execution.