### PR TITLE
Bump scheduled shutdown to 10 hours

### DIFF
--- a/scripts/bb-test-prepare.sh
+++ b/scripts/bb-test-prepare.sh
@@ -227,7 +227,7 @@ case "$BB_NAME" in
         ;;
     *)
         echo "Scheduling shutdown"
-        sudo -E shutdown +480
+        sudo -E shutdown +600
         ;;
 esac
 


### PR DESCRIPTION
Coverage builds may run longer than the previous 8 hour limit. Bump up the amount of time TEST builders can run to 10 hours.