### PR TITLE
Modify default sudo umask

### DIFF
--- a/scripts/bb-bootstrap.sh
+++ b/scripts/bb-bootstrap.sh
@@ -110,9 +110,13 @@ Amazon*)
     fi
 
     # User buildbot needs to be added to sudoers and requiretty disabled.
+    # Set the sudo umask to 0000, this ensures that all .gcda profiling files
+    # will be modifiable by the buildbot user even when created under sudo.
     if ! id -u buildbot >/dev/null 2>&1; then
         adduser buildbot
         echo "buildbot  ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
+        echo "Defaults umask = 0000" >> /etc/sudoers
+        echo "Defaults umask_override" >> /etc/sudoers
         sed -i.bak 's/ requiretty/ !requiretty/' /etc/sudoers
         sed -i.bak '/secure_path/a\Defaults exempt_group+=buildbot' /etc/sudoers
     fi


### PR DESCRIPTION
When bootstrapping a TEST builder override the default umask used
by sudo to always be 0000.  This ensures that any profiling files
created by sudo will have permissions 0666 any therefore can be
modified by the normal buildbot user.