### PR TITLE
codecov: log static HTML coverage reports

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -437,6 +437,8 @@ test_factory.addStep(ShellCommand(
     command=["runurl", bb_url + "bb-test-cleanup.sh"],
     haltOnFailure=False, maxTime=1800, sigtermTime=30, logEnviron=False,
     lazylogfiles=True,
+    logfiles={"coverage-user"   : { "filename" : "coverage-user.tar.xz",   "follow" : False },
+              "coverage-kernel" : { "filename" : "coverage-kernel.tar.xz", "follow" : False }},
     decodeRC={0 : SUCCESS, 1 : FAILURE, 2 : WARNINGS, 3 : SKIPPED },
     description=["analysis"], descriptionDone=["analysis"],
     hideStepIf=lambda results, s: results==SKIPPED))

--- a/scripts/bb-dependencies.sh
+++ b/scripts/bb-dependencies.sh
@@ -127,7 +127,7 @@ Ubuntu*)
     # Required utilities.
     sudo -E apt-get --yes install git alien fakeroot wget curl bc fio acl \
         sysstat mdadm lsscsi parted gdebi attr dbench watchdog ksh \
-        nfs-kernel-server samba rng-tools
+        nfs-kernel-server samba rng-tools xz-utils
 
     # Required development libraries
     sudo -E apt-get --yes install linux-headers-$(uname -r) \


### PR DESCRIPTION
NOTE: This patch hasn't been tested.

This patch attempts to collect and log the static HTML coverage reports
that are generated via `make code-coverage-capture`, such that they can
be easily downloaded using the Buildbot UI, and viewed on a developer's
local workstation.