### PR TITLE
codecov: fix missing redirection

### DIFF
--- a/scripts/bb-test-cleanup.sh
+++ b/scripts/bb-test-cleanup.sh
@@ -113,7 +113,7 @@ function upload_codecov_report_with_flag
     #
     if [[ -n "$TEST_CODE_COVERAGE_HTML" ]]; then
         tar -cf - "$CODE_COVERAGE_OUTPUT_DIRECTORY" | \
-            xz -9e "${WORKDIR}/${CODE_COVERAGE_OUTPUT_DIRECTORY}.tar.xz"
+            xz -9e > "${WORKDIR}/${CODE_COVERAGE_OUTPUT_DIRECTORY}.tar.xz"
     fi
 }
 


### PR DESCRIPTION
The prior commit to export the HTML coverage reports is broken due to it
missing the required redirection operator. Here's what the error message
would look like:

```
+ xz -9e /var/lib/buildbot/slaves/zfs/Ubuntu_17_04_x86_64_Coverage__TEST_/build/tests/coverage-user.tar.xz
+ tar -cf - coverage-user
xz: /var/lib/buildbot/slaves/zfs/Ubuntu_17_04_x86_64_Coverage__TEST_/build/tests/coverage-user.tar.xz: No such file or directory
```

This patch attempts to fix the issue.