### PR TITLE
coverage: add verbosity when collecting code coverage

### DIFF
--- a/scripts/bb-test-cleanup.sh
+++ b/scripts/bb-test-cleanup.sh
@@ -88,7 +88,7 @@ function upload_codecov_report_with_flag
     #
     export CODE_COVERAGE_OUTPUT_DIRECTORY="coverage-$1"
 
-    make code-coverage-capture
+    make V=1 code-coverage-capture
     curl -s https://codecov.io/bash | bash -s - \
         -c -Z -X gcov -X py -X xcode \
         -n "$BUILDER_NAME" \


### PR DESCRIPTION
This patch enables more verbosity to be output when collecting the code
coverage data, which can be useful to have when debugging problems. For
example, without the additional verbosity, not much is emitted:

    $ make code-coverage-capture
      LCOV   --capture zfs-0.7.0-coverage.info
      LCOV   --remove /tmp/*
    lcov: WARNING: negative counts found in tracefile zfs-0.7.0-coverage.info.tmp
      GEN    zfs-0.7.0-coverage
    file:///export/home/delphix/zfs/zfs-0.7.0-coverage/index.html

But when we enable more verbosity, we get more useful data emitted:

    $ make V=1 code-coverage-capture
    lcov  --directory . --capture --output-file "zfs-0.7.0-coverage.info.tmp" --test-name "zfs_0_7_0" --no-checksum --compat-libtool  --gcov-tool "gcov"
    Capturing coverage data from .
    Found gcov version: 6.3.0
    Scanning . for .gcda files ...
    Found 206 data files in .
    Processing lib/libzfs_core/.libs/libzfs_core.gcda
    Processing lib/libshare/.libs/smb.gcda
    Processing lib/libshare/.libs/nfs.gcda
    Processing lib/libshare/.libs/libshare.gcda
    ...

Having this extra information logged in Buildbot may be useful to have,
if we ever need to go back and scrutinize the code coverage data
generated for a particular commit.

Signed-off-by: Prakash Surya <prakash.surya@delphix.com>