### PR TITLE
Add support for DKMS packages

### DIFF
--- a/scripts/bb-build.sh
+++ b/scripts/bb-build.sh
@@ -23,65 +23,72 @@ fi
 set -x
 
 sh ./autogen.sh >>$CONFIG_LOG 2>&1 || exit 1
-./configure $CONFIG_OPTIONS $LINUX_OPTIONS >>$CONFIG_LOG 2>&1 || exit 1
 
-if [ "$INSTALL_METHOD" = "packages" ]; then
-	make pkg >>$MAKE_LOG 2>&1 || exit 1
+case "$INSTALL_METHOD" in
+packages|kmod|pkg-kmod|dkms|dkms-kmod)
+	case "$INSTALL_METHOD" in
+	packages|kmod|pkg-kmod)
+		./configure $CONFIG_OPTIONS $LINUX_OPTIONS \
+		    >>$CONFIG_LOG 2>&1 || exit 1
+		make pkg-kmod >>$MAKE_LOG 2>&1 || exit 1
+		;;
+	dkms|pkg-dkms)
+		./configure --with-config=srpm $CONFIG_OPTIONS $LINUX_OPTIONS \
+		    >>$CONFIG_LOG 2>&1 || exit 1
+		make pkg-dkms >>$MAKE_LOG 2>&1 || exit 1
+		;;
+	esac
+
+	make pkg-utils >>$MAKE_LOG 2>&1 || exit 1
+	sudo -E rm *.src.rpm
 
 	case "$BB_NAME" in
 	Amazon*)
-		sudo -E rm *.src.rpm *.noarch.rpm >>$INSTALL_LOG 2>&1
-		sudo -E yum -y localinstall *.rpm >>$INSTALL_LOG 2>&1 || exit 1
+		sudo -E yum -y localinstall *.rpm >$INSTALL_LOG 2>&1 || exit 1
 		;;
-
 	CentOS*)
-		sudo -E rm *.src.rpm *.noarch.rpm >>$INSTALL_LOG 2>&1
-		sudo -E yum -y localinstall *.rpm >>$INSTALL_LOG 2>&1 || exit 1
+		sudo -E yum -y localinstall *.rpm >$INSTALL_LOG 2>&1 || exit 1
 		;;
-
 	Debian*)
-		for file in *.deb; do
-			sudo -E gdebi -q --non-interactive $file \
-			    >>$INSTALL_LOG 2>&1 || exit 1
-		done
+		sudo -E apt-get -y install ./*.deb >$INSTALL_LOG 2>&1 || exit 1
 		;;
-
 	Fedora*)
-		sudo -E rm *.src.rpm *.noarch.rpm >>$INSTALL_LOG 2>&1
-		sudo -E dnf -y localinstall *.rpm >>$INSTALL_LOG 2>&1 || exit 1
+		sudo -E dnf -y localinstall *.rpm >$INSTALL_LOG 2>&1 || exit 1
 		;;
-
 	RHEL*)
-		sudo -E rm *.src.rpm *.noarch.rpm >>$INSTALL_LOG 2>&1
-		sudo -E yum -y localinstall *.rpm >>$INSTALL_LOG 2>&1 || exit 1
+		sudo -E yum -y localinstall *.rpm >$INSTALL_LOG 2>&1 || exit 1
 		;;
-
 	SUSE*)
-		sudo -E rm *.src.rpm *.noarch.rpm >>$INSTALL_LOG 2>&1
 		sudo -E zypper --non-interactive install *.rpm \
-		    >>$INSTALL_LOG 2>&1 || exit 1
+		    >$INSTALL_LOG 2>&1 || exit 1
 		;;
-
-	Ubuntu*)
+	Ubuntu-14.04*)
 		for file in *.deb; do
-		sudo -E gdebi -q --non-interactive $file \
-		    >>$INSTALL_LOG 2>&1 || exit 1
+			sudo -E gdebi -n $file >$INSTALL_LOG 2>&1 || exit 1
 		done
 		;;
-
+	Ubuntu*)
+		sudo -E apt-get -y install ./*.deb >$INSTALL_LOG 2>&1 || exit 1
+		;;
 	*)
-		echo "$BB_NAME unknown platform" >>$INSTALL_LOG 2>&1
+		echo "$BB_NAME unknown platform" >$INSTALL_LOG 2>&1
 		;;
 	esac
-elif [ "$INSTALL_METHOD" = "in-tree" ]; then
+	;;
+in-tree)
+	./configure $CONFIG_OPTIONS $LINUX_OPTIONS >>$CONFIG_LOG 2>&1 || exit 1
 	make $MAKE_OPTIONS >>$MAKE_LOG 2>&1 || exit 1
 	./scripts/zfs-tests.sh -cv >>$INSTALL_LOG 2>&1
 	sudo -E scripts/zfs-helpers.sh -iv >>$INSTALL_LOG 2>&1
-elif [ "$INSTALL_METHOD" = "none" ]; then
+	;;
+none)
+	./configure $CONFIG_OPTIONS $LINUX_OPTIONS >>$CONFIG_LOG 2>&1 || exit 1
 	make $MAKE_OPTIONS >>$MAKE_LOG 2>&1 || exit 1
-else
+	;;
+*)
 	echo "Unknown INSTALL_METHOD: $INSTALL_METHOD"
 	exit 1
-fi
+	;;
+esac
 
 exit 0

--- a/scripts/bb-cleanup.sh
+++ b/scripts/bb-cleanup.sh
@@ -15,74 +15,64 @@ set -x
 case "$BB_NAME" in
 Amazon*)
     if test "$BUILT_PACKAGE" = "zfs"; then
-        sudo -E yum -y remove \
-            kmod-zfs-$(uname -r) kmod-zfs-devel-$(uname -r) \
+        sudo -E yum -y remove '(zfs-dkms.*|kmod-zfs.*)' \
             libnvpair1 libuutil1 libzfs2 libzpool2 libzfs2-devel \
             zfs zfs-debuginfo zfs-kmod-debuginfo zfs-dracut  zfs-test
     fi
 
     if test "$BUILT_PACKAGE" = "spl"; then
-        sudo -E yum -y remove \
-            kmod-spl-$(uname -r) kmod-spl-devel-$(uname -r) \
-            spl spl-debuginfo spl-kmod-debuginfo
+        sudo -E yum -y remove '(spl-dkms.*|kmod-spl.*)' \
+	    spl spl-debuginfo spl-kmod-debuginfo
     fi
     ;;
 
 CentOS*)
     if test "$BUILT_PACKAGE" = "zfs"; then
-        sudo -E yum -y remove \
-            kmod-zfs kmod-zfs-devel \
+        sudo -E yum -y remove '(zfs-dkms.*|kmod-zfs.*)' \
             libnvpair1 libuutil1 libzfs2 libzpool2 libzfs2-devel \
             zfs zfs-debuginfo zfs-kmod-debuginfo zfs-dracut zfs-test
     fi
 
     if test "$BUILT_PACKAGE" = "spl"; then
-        sudo -E yum -y remove \
-            kmod-spl-$(uname -r) kmod-spl-devel-$(uname -r) \
+        sudo -E yum -y remove '(spl-dkms.*|kmod-spl.*)' \
             spl spl-debuginfo spl-kmod-debuginfo
     fi
     ;;
 
 Debian*)
     if test "$BUILT_PACKAGE" = "zfs"; then
-        sudo -E apt-get --yes purge \
-            kmod-zfs-$(uname -r) kmod-zfs-devel-$(uname -r) \
+        sudo -E apt-get --yes purge '(zfs-dkms.*|kmod-zfs.*)' \
             libnvpair1 libuutil1 libzfs2 libzpool2 libzfs2-devel \
             zfs zfs-initramfs zfs-dracut zfs-test
     fi
 
     if test "$BUILT_PACKAGE" = "spl"; then
-        sudo -E apt-get --yes purge \
-            kmod-spl-$(uname -r) kmod-spl-devel-$(uname -r) spl
+        sudo -E apt-get --yes purge '(spl-dkms.*|kmod-spl.*)' spl
     fi
     ;;
 
 Fedora*)
     if test "$BUILT_PACKAGE" = "zfs"; then
-        sudo -E dnf -y remove \
-            kmod-zfs-$(uname -r) kmod-zfs-devel-$(uname -r) \
+        sudo -E dnf -y remove '(zfs-dkms.*|kmod-zfs.*)' \
             libnvpair1 libuutil1 libzfs2 libzpool2 libzfs2-devel \
             zfs zfs-debuginfo zfs-kmod-debuginfo zfs-dracut zfs-test
     fi
 
     if test "$BUILT_PACKAGE" = "spl"; then
-        sudo -E dnf -y remove \
-            kmod-spl-$(uname -r) kmod-spl-devel-$(uname -r) \
+        sudo -E dnf -y remove '(spl-dkms.*|kmod-spl.*)' \
             spl spl-debuginfo spl-kmod-debuginfo
     fi
     ;;
 
 RHEL*)
     if test "$BUILT_PACKAGE" = "zfs"; then
-        sudo -E yum -y remove \
-            kmod-zfs kmod-zfs-devel \
+        sudo -E yum -y remove '(zfs-dkms.*|kmod-zfs.*)' \
             libnvpair1 libuutil1 libzfs2 libzpool2 libzfs2-devel \
             zfs zfs-debuginfo zfs-kmod-debuginfo zfs-dracut zfs-test
     fi
 
     if test "$BUILT_PACKAGE" = "spl"; then
-        sudo -E yum -y remove \
-            kmod-spl-$(uname -r) kmod-spl-devel-$(uname -r) \
+        sudo -E yum -y remove '(spl-dkms.*|kmod-spl.*)' \
             spl spl-debuginfo spl-kmod-debuginfo
     fi
     ;;
@@ -101,15 +91,13 @@ SUSE*)
 
 Ubuntu*)
     if test "$BUILT_PACKAGE" = "zfs"; then
-        sudo -E apt-get --yes purge \
-            kmod-zfs-$(uname -r) kmod-zfs-devel-$(uname -r) \
+        sudo -E apt-get --yes purge '(zfs-dkms.*|kmod-zfs.*)' \
             libnvpair1 libuutil1 libzfs2 libzpool2 libzfs2-devel \
             zfs zfs-initramfs zfs-dracut zfs-test
     fi
 
     if test "$BUILT_PACKAGE" = "spl"; then
-        sudo -E apt-get --yes purge \
-            kmod-spl-$(uname -r) kmod-spl-devel-$(uname -r) spl
+        sudo -E apt-get --yes purge '(spl-dkms.*|kmod-spl.*)' spl
     fi
     ;;
 

--- a/scripts/bb-dependencies.sh
+++ b/scripts/bb-dependencies.sh
@@ -19,7 +19,7 @@ Amazon*)
     # Required utilities.
     sudo -E yum -y install git rpm-build wget curl bc fio acl sysstat \
         mdadm lsscsi parted attr dbench watchdog ksh nfs-utils samba \
-        rng-tools
+        rng-tools dkms
     sudo -E yum -y install --enablerepo=epel cppcheck pax-utils
 
     # Required development libraries
@@ -38,7 +38,7 @@ CentOS*)
     # Required utilities.
     sudo -E yum -y install git rpm-build wget curl bc fio acl sysstat \
         mdadm lsscsi parted attr dbench watchdog ksh nfs-utils samba \
-        rng-tools
+        rng-tools dkms
 
     # Required development libraries
     sudo -E yum -y install kernel-devel \
@@ -55,7 +55,7 @@ Debian*)
     # Required utilities.
     sudo -E apt-get --yes install git alien fakeroot wget curl bc fio acl \
         sysstat lsscsi parted gdebi attr dbench watchdog ksh nfs-kernel-server \
-        samba rng-tools
+        samba rng-tools dkms
 
     # Required development libraries
     sudo -E apt-get --yes install linux-headers-$(uname -r) \
@@ -71,7 +71,7 @@ Fedora*)
     # Required utilities.
     sudo -E dnf -y install git rpm-build wget curl bc fio acl sysstat \
         mdadm lsscsi parted attr dbench watchdog ksh nfs-utils samba \
-        rng-tools
+        rng-tools dkms
 
     # Required development libraries
     sudo -E dnf -y install kernel-devel-$(uname -r) zlib-devel \
@@ -95,7 +95,7 @@ RHEL*)
     # Required utilities.
     sudo -E yum -y install git rpm-build wget curl bc fio acl sysstat \
         mdadm lsscsi parted attr dbench watchdog ksh nfs-utils samba \
-        rng-tools
+        rng-tools dkms
 
     # Required development libraries
     sudo -E yum -y $EXTRA_REPO install kernel-devel-$(uname -r) zlib-devel \
@@ -111,7 +111,7 @@ SUSE*)
     # Required utilities.
     sudo -E zypper --non-interactive install git rpm-build wget curl bc \
         fio acl sysstat mdadm lsscsi parted attr ksh nfs-kernel-server \
-        samba rng-tools
+        samba rng-tools dkms
 
     # Required development libraries
     sudo -E zypper --non-interactive install kernel-devel zlib-devel \
@@ -127,7 +127,7 @@ Ubuntu*)
     # Required utilities.
     sudo -E apt-get --yes install git alien fakeroot wget curl bc fio acl \
         sysstat mdadm lsscsi parted gdebi attr dbench watchdog ksh \
-        nfs-kernel-server samba rng-tools xz-utils
+        nfs-kernel-server samba rng-tools xz-utils dkms
 
     # Required development libraries
     sudo -E apt-get --yes install linux-headers-$(uname -r) \

--- a/scripts/bb-test-prepare.sh
+++ b/scripts/bb-test-prepare.sh
@@ -59,14 +59,14 @@ cat << EOF >> $TEST_FILE
 SPL_BUILD_DIR=$SPL_BUILD_DIR
 ZFS_BUILD_DIR=$ZFS_BUILD_DIR
 TEST_DIR=$TEST_DIR
-
 TEST_METHOD=$TEST_METHOD
 
 EOF
 
 # Add environment variables for "packages" or "in-tree" testing.
 TEST_METHOD=${TEST_METHOD:-"packages"}
-if [ "$TEST_METHOD" = "packages" ]; then
+case "$TEST_METHOD" in
+packages|kmod|pkg-kmod|dkms|dkms-kmod)
     cat << EOF >> $TEST_FILE
 SPLAT=${SPLAT:-"splat"}
 ZPOOL=${ZPOOL:-"zpool"}
@@ -77,7 +77,8 @@ ZFS_TESTS_SH=${ZFS_TESTS_SH:-"zfs-tests.sh"}
 ZIMPORT_SH=${ZIMPORT_SH:-"zimport.sh"}
 ZLOOP_SH=${ZLOOP_SH:-"zloop.sh"}
 EOF
-elif [ "$TEST_METHOD" = "in-tree" ]; then
+    ;;
+in-tree)
     cat << EOF >> $TEST_FILE
 SPLAT=${SPLAT:-"\$SPL_BUILD_DIR/bin/splat"}
 ZPOOL=${ZPOOL:-"\$ZFS_BUILD_DIR/bin/zpool"}
@@ -88,12 +89,14 @@ ZFS_TESTS_SH=${ZFS_TESTS_SH:-"\$ZFS_BUILD_DIR/scripts/zfs-tests.sh"}
 ZIMPORT_SH=${ZIMPORT_SH:-"\$ZFS_BUILD_DIR/scripts/zimport.sh"}
 ZLOOP_SH=${ZLOOP_SH:-"\$ZFS_BUILD_DIR/scripts/zloop.sh"}
 EOF
-else
+    ;;
+*)
     cat << EOF >> $TEST_FILE
 echo "Unknown TEST_METHOD: $TEST_METHOD"
 exit 1
 EOF
-fi
+    ;;
+esac
 
 . $TEST_FILE
 


### PR DESCRIPTION
Provide the needed functionality to build and install DKMS style
packages on the TEST builders.

Enabling this functionality will be done in a followup patch once
full support has been merged to the ZFS tree.