### PR TITLE
Enable DKMS package builds

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -857,9 +857,9 @@ perf_tags = [ "Performance" ]
 # Properties are used to control how a build is performed.
 builder_default_properties = {
     "buildlinux":    "no",
+    "buildlustre":   "no",
     "buildspl":      "yes",
     "buildzfs":      "yes",
-    "buildlustre":   "no",
     "builtin":       "no",
     "configlustre":  "",
     "configspl":     "--enable-debug",
@@ -872,9 +872,9 @@ builder_default_properties = {
 
 builder_coverage_properties = {
     "buildlinux":    "no",
+    "buildlustre":   "no",
     "buildspl":      "yes",
     "buildzfs":      "yes",
-    "buildlustre":   "no",
     "builtin":       "no",
     "configlustre":  "",
     "configspl":     "--enable-debug",
@@ -895,6 +895,21 @@ builder_lustre_properties = {
     "configspl":     "--with-spec=redhat",
     "configzfs":     "--with-spec=redhat",
     "install":       "packages",
+    "repoowner":     "zfsonlinux",
+    "reponame":      "zfs",
+    "checklint":     "no",
+}
+
+builder_dkms_properties = {
+    "buildlinux":    "no",
+    "buildlustre":   "no",
+    "buildspl":      "yes",
+    "buildzfs":      "yes",
+    "builtin":       "no",
+    "configlustre":  "",
+    "configspl":     "--enable-debug",
+    "configzfs":     "--enable-debug --enable-debuginfo",
+    "install":       "dkms",
     "repoowner":     "zfsonlinux",
     "reponame":      "zfs",
     "checklint":     "no",
@@ -1225,14 +1240,14 @@ test_builders = [
         factory=test_factory,
         slavenames=[slave.name for slave in ubuntu16_x86_64_testslave],
         tags=test_tags,
-        properties=builder_default_properties,
+        properties=builder_dkms_properties,
     ),
     ZFSBuilderConfig(
         name="Ubuntu 17.04 x86_64 (TEST)",
         factory=test_factory,
         slavenames=[slave.name for slave in ubuntu17_x86_64_testslave],
         tags=test_tags,
-        properties=builder_default_properties,
+        properties=builder_dkms_properties,
     ),
     ZFSBuilderConfig(
         name="Ubuntu 17.04 x86_64 Coverage (TEST)",


### PR DESCRIPTION
Use DKMS style packages for Ubuntu 16.04 and 17.04 testing.  By
using the DKMS packages in testing we'll be sure they're always
working properly, and it allows us to minimize our dependency on
alien when testing on non-rpm based distributions.