### PR TITLE
bb-test-ztest.sh: Trap SIGTERM

### DIFF
--- a/scripts/bb-test-ztest.sh
+++ b/scripts/bb-test-ztest.sh
@@ -19,15 +19,12 @@ fi
 
 CONSOLE_LOG="$PWD/console.log"
 
-# Cleanup the pool and restore any modified system state.  The console log
-# is dumped twice to maximize the odds of preserving debug information.
 cleanup()
 {
-    dmesg >$CONSOLE_LOG
     sudo -E $ZFS_SH -u
     dmesg >$CONSOLE_LOG
 }
-trap cleanup EXIT
+trap cleanup EXIT TERM
 
 set -x
 


### PR DESCRIPTION
If zloop.sh hangs and exceeds the allowed buildbot log timeout it
will be sent SIGTERM.   In this case the EXIT handler will not be
run and the modules loaded.  Subsequent test build steps will fail
when trying to load the modules.

Additionally remove the redundant console dump.  This test runs
entirely in user space and it's unlikely to trigger a problem in
the loaded modules.