### PR TITLE
Remove clean env step from PERF builder

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -547,15 +547,6 @@ perf_factory.addStep(ShellCommand(
     decodeRC={0 : SUCCESS, 1 : FAILURE, 2 : WARNINGS, 3 : SKIPPED },
     timeout=5400, description=["zfstests"], descriptionDone=["zfstests"],
     hideStepIf=lambda results, s: results==SKIPPED))
-perf_factory.addStep(ShellCommand(
-    workdir="build/tests",
-    env={'PATH' : bin_path + ":" + zfs_path},
-    command=["runurl", bb_url + "bb-test-cleanup.sh"],
-    haltOnFailure=False, maxTime=120, sigtermTime=30, logEnviron=False,
-    lazylogfiles=True,
-    logfiles={"test"     : { "filename" : "TEST",        "follow" : False }},
-    decodeRC={0 : SUCCESS, 1 : FAILURE, 2 : WARNINGS, 3 : SKIPPED },
-    description=["cleaning env"], descriptionDone=["cleaned env"]))
 perf_factory.addStep(ShellCommand(command=["runurl", bb_url + "bb-cleanup.sh"],
     env={'PATH' : bin_path, 'BUILT_PACKAGE' : 'zfs'},
     haltOnFailure=False, logEnviron=False,


### PR DESCRIPTION
The PERF builder will always skip the clean env step
since gcov is not installed on it. The build step
is safe to remove from the performance build factory.

Signed-off-by: Giuseppe Di Natale <dinatale2@llnl.gov>