### PR TITLE
Disable zfsstress by default on TEST builders

### DIFF
--- a/scripts/bb-test-zfsstress.sh
+++ b/scripts/bb-test-zfsstress.sh
@@ -11,7 +11,7 @@ else
     exit 1
 fi
 
-TEST_ZFSSTRESS_SKIP=${TEST_ZFSSTRESS_SKIP:-"No"}
+TEST_ZFSSTRESS_SKIP=${TEST_ZFSSTRESS_SKIP:-"Yes"}
 if echo "$TEST_ZFSSTRESS_SKIP" | grep -Eiq "^yes$|^on$|^true$|^1$"; then
     echo "Skipping disabled test"
     exit 3


### PR DESCRIPTION
Now that the vast majority of the ZTS is running there is less
value in always running this test suite.  It can be enabled when
needed by setting TEST_ZFSSTRESS_SKIP="No" in your commit message.

As an aside, these test scripts predate getting the ZTS framework
working on Linux.  It would be useful to adapt them to the ZTS and
include them under tests/zfs-tests/tests/stress/.