### PR TITLE
Fix "binary file log matches" error

### DIFF
--- a/scripts/bb-test-zfstests.sh
+++ b/scripts/bb-test-zfstests.sh
@@ -75,8 +75,8 @@ $ZFS_TESTS_SH $TEST_ZFSTESTS_OPTIONS \
 RC=$?
 
 if [ $RC -ne 0 ]; then
-    grep "\[KILLED\]" log && RESULT=2  # WARNING
-    grep "\[FAIL\]" log && RESULT=1    # FAILURE
+    grep -a "\[KILLED\]" log && RESULT=2  # WARNING
+    grep -a "\[FAIL\]" log && RESULT=1    # FAILURE
 fi
 
 if $(dmesg | grep "oom-killer"); then


### PR DESCRIPTION
grep sometimes believes that the main log output
file is a binary file, which stops processing
of the failed/killed output at the end of the
test run.  Changing grep syntax should correct
this.

eg: http://build.zfsonlinux.org/builders/Fedora%2027%20x86_64%20%28TEST%29/builds/50/steps/shell_8/logs/stdio