### PR TITLE
Move Coverage Builder into separate build category

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -774,13 +774,6 @@ ubuntu17_x86_64_testslave = [
     ) for i in range(0, numtestslaves)
 ]
 
-ubuntu17_x86_64_coverage_testslave = [
-    ZFSEC2TestSlave(
-        name="Ubuntu-17.04-x86_64-coverage-testslave%s" % (str(i+1)),
-        ami="ami-4195a321"
-    ) for i in range(0, numtestslaves)
-]
-
 ubuntu14_i686_testslave = [
     ZFSEC2PVTestSlave(
         name="Ubuntu-14.04-i686-testslave%s" % (str(i+1)),
@@ -796,8 +789,18 @@ test_slaves = \
     fedora27_x86_64_testslave + \
     ubuntu16_x86_64_testslave + \
     ubuntu17_x86_64_testslave + \
-    ubuntu17_x86_64_coverage_testslave + \
     ubuntu14_i686_testslave
+
+# Coverage slaves
+ubuntu17_x86_64_coverage_testslave = [
+    ZFSEC2TestSlave(
+        name="Ubuntu-17.04-x86_64-coverage-testslave%s" % (str(i+1)),
+        ami="ami-4195a321"
+    ) for i in range(0, numtestslaves)
+]
+
+coverage_slaves = \
+    ubuntu17_x86_64_coverage_testslave
 
 # Performance slaves
 numperfslaves = 2
@@ -819,6 +822,7 @@ all_slaves = \
     distro_slaves + \
     arch_slaves + \
     test_slaves + \
+    coverage_slaves + \
     perf_slaves
 
 style_tags = [ "Style" ]
@@ -1234,18 +1238,22 @@ test_builders = [
         properties=builder_dkms_properties,
     ),
     ZFSBuilderConfig(
-        name="Ubuntu 17.04 x86_64 Coverage (TEST)",
-        factory=test_factory,
-        slavenames=[slave.name for slave in ubuntu17_x86_64_coverage_testslave],
-        tags=test_tags,
-        properties=builder_coverage_properties,
-    ),
-    ZFSBuilderConfig(
         name="Ubuntu 14.04 i686 (TEST)",
         factory=test_factory,
         slavenames=[slave.name for slave in ubuntu14_i686_testslave],
         tags=test_tags,
         properties=builder_default_properties,
+    ),
+]
+
+# coverage builders
+coverage_builders = [
+    ZFSBuilderConfig(
+        name="Ubuntu 17.04 x86_64 Coverage (TEST)",
+        factory=test_factory,
+        slavenames=[slave.name for slave in ubuntu17_x86_64_coverage_testslave],
+        tags=test_tags,
+        properties=builder_coverage_properties,
     ),
 ]
 
@@ -1267,6 +1275,7 @@ all_builders = \
     arch_builders + \
     release_builders + \
     test_builders + \
+    coverage_builders + \
     perf_builders
 
 c['slaves'] = all_slaves 
@@ -1366,7 +1375,7 @@ class CustomGitHubEventHandler(GitHubEventHandler):
 
             # Annotate the head commit to allow special handling.
             if commit['sha'] == payload['pull_request']['head']['sha']:
-                category = "style,build,test"
+                category = "style,build,test,coverage"
             else:
                 category = "style,build"
 
@@ -1396,7 +1405,7 @@ class CustomGitHubEventHandler(GitHubEventHandler):
                 all_pattern = '.*all.*'
                 m = re.search(all_pattern, category, re.I | re.M)
                 if m is not None:
-                    category = "style,build,test,perf"
+                    category = "style,build,test,perf,coverage"
 
             # Annotate every commit with 'Requires-spl' when missing.
             comments = commit['commit']['message'] + "\n\n"
@@ -1457,6 +1466,7 @@ distro_builders = [builder.name for builder in distro_builders]
 arch_builders = [builder.name for builder in arch_builders]
 test_builders = [builder.name for builder in test_builders]
 perf_builders = [builder.name for builder in perf_builders]
+coverage_builders = [builder.name for builder in coverage_builders]
 
 c['schedulers'] = []
 
@@ -1539,6 +1549,13 @@ c['schedulers'].append(CustomSingleBranchScheduler(
     builderNames=perf_builders,
     codebases=default_codebases,
     change_filter=filter.ChangeFilter(category_re=".*perf.*")))
+
+# This scheduler is for pull requests.
+c['schedulers'].append(CustomSingleBranchScheduler(
+    name="pull-request-coverage-scheduler",
+    builderNames=coverage_builders,
+    codebases=default_codebases,
+    change_filter=filter.ChangeFilter(category_re=".*coverage.*")))
 
 # This scheduler is for pushes to branches.
 c['schedulers'].append(CustomSingleBranchScheduler(


### PR DESCRIPTION
For WIP pull requests, developers would like the option to
skip coverage testing until their PR is closer to a final
version.

Signed-off-by: Giuseppe Di Natale <dinatale2@llnl.gov>