### PR TITLE
Add documentation for Coverage builders to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,8 +45,8 @@ By default, all commits in your ZFS pull request are compiled by the BUILD
 builders.  Additionally, the top commit of your ZFS pull request is tested by
 TEST builders. However, there is the option to override which types of builder
 should be used on a per commit basis. In this case, you can add
-`Requires-builders: <none|all|style|build|arch|distro|test|perf>` to your
-commit message. A comma separated list of options can be
+`Requires-builders: <none|all|style|build|arch|distro|test|perf|coverage>` to
+your commit message. A comma separated list of options can be
 provided. Supported options are:
 
 * `all`: This commit should be built by all available builders
@@ -61,9 +61,12 @@ provided. Supported options are:
 
 * `distro`: This commit should be built by BUILD builders tagged as 'Distributions'
 
-* `test`: This commit should be built and tested by the TEST builders
+* `test`: This commit should be built and tested by the TEST builders (excluding
+Coverage TEST builders)
 
 * `perf`: This commit should be built and tested by the PERF builders
+
+* `coverage`: This commit should be built and test by the Coverage TEST builders
 
 ### Builder Types
 


### PR DESCRIPTION
Coverage builders are now a different class of TEST builder.
Add information regarding Coverage builders to the README.

Signed-off-by: Giuseppe Di Natale <dinatale2@llnl.gov>