### PR TITLE
Correct built in kernel builds

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -88,6 +88,14 @@ def do_step_build_spl(step):
 def do_step_build_zfs(step):
     return do_step_build(step, 'buildzfs')
 
+def perform_spl_build(step):
+    return do_step_build(step, 'buildspl') and \
+        not do_step_build(step, 'builtin')
+
+def perform_zfs_build(step):
+    return do_step_build(step, 'buildzfs') and \
+        not do_step_build(step, 'builtin')
+
 def do_step_check_lint(step):
     return do_step_build(step, 'checklint')
 
@@ -220,8 +228,12 @@ build_factory.addStep(ShellCommand(
     haltOnFailure=True, logEnviron=False,
     lazylogfiles=True,
     logfiles={"configure"  : { "filename" : "configure.log", "follow" : True },
-              ".config"    : { "filename" : ".config",       "follow" : False},
-              "make"       : { "filename" : "make.log",      "follow" : True }},
+              ".config"    : { "filename" : ".config",       "follow" : False },
+              "make"       : { "filename" : "make.log",      "follow" : True },
+              "config.spl.log" :
+                  { "filename" : "../spl/config.log", "follow" : True },
+              "config.zfs.log" :
+                  { "filename" : "../zfs/config.log", "follow" : True }},
     decodeRC={0 : SUCCESS, 1 : FAILURE, 2 : WARNINGS, 3 : SKIPPED },
     description=["building linux"], descriptionDone=["built linux"],
     doStepIf = do_step_build_linux,
@@ -239,7 +251,7 @@ build_factory.addStep(ShellCommand(
               "make"       : { "filename" : "make.log",      "follow" : True }},
     decodeRC={0 : SUCCESS, 1 : FAILURE, 2 : WARNINGS, 3 : SKIPPED },
     description=["building spl"], descriptionDone=["built spl"],
-    doStepIf = do_step_build_spl,
+    doStepIf = perform_spl_build,
     hideStepIf=lambda results, s: results==SKIPPED))
 build_factory.addStep(ShellCommand(
     workdir="build/zfs", env={'PATH' : bin_path,
@@ -254,7 +266,7 @@ build_factory.addStep(ShellCommand(
               "make"       : { "filename" : "make.log",      "follow" : True }},
     decodeRC={0 : SUCCESS, 1 : FAILURE, 2 : WARNINGS, 3 : SKIPPED },
     description=["building zfs"], descriptionDone=["built zfs"],
-    doStepIf = do_step_build_zfs,
+    doStepIf = perform_zfs_build,
     hideStepIf=lambda results, s: results==SKIPPED))
 build_factory.addStep(ShellCommand(command=["make", "lint"],
     workdir="build/zfs", logEnviron=False, env={'PATH' : bin_path},
@@ -955,8 +967,8 @@ builder_linux_properties = {
 builder_builtin_properties = {
     "buildlinux":    "yes",
     "buildlustre":   "no",
-    "buildspl":      "no",
-    "buildzfs":      "no",
+    "buildspl":      "yes",
+    "buildzfs":      "yes",
     "builtin":       "yes",
     "configlustre":  "",
     "configspl":     "--enable-debug",

--- a/scripts/bb-build-linux.sh
+++ b/scripts/bb-build-linux.sh
@@ -37,21 +37,17 @@ if test "$LINUX_BUILTIN" = "yes"; then
         ./copy-builtin $LINUX_DIR >>$CONFIG_LOG 2>&1 || exit 1
     fi
 
-    if [ -d "../zfs" ]; then
-        cd ../zfs >>$CONFIG_LOG 2>&1 || exit 1
-        sh ./autogen.sh >>$CONFIG_LOG 2>&1 || exit 1
-        ./configure $CONFIG_OPTIONS $LINUX_OPTIONS >>$CONFIG_LOG 2>&1 || exit 1
-        ./copy-builtin $LINUX_DIR >>$CONFIG_LOG 2>&1 || exit 1
-    fi
+    cd ../zfs >>$CONFIG_LOG 2>&1 || exit 1
+    sh ./autogen.sh >>$CONFIG_LOG 2>&1 || exit 1
+    ./configure $CONFIG_OPTIONS $LINUX_OPTIONS >>$CONFIG_LOG 2>&1 || exit 1
+    ./copy-builtin $LINUX_DIR >>$CONFIG_LOG 2>&1 || exit 1
 
     cd ../linux >>$CONFIG_LOG 2>&1 || exit 1
     if [ -d "../spl" ]; then
       echo "CONFIG_SPL=y" >>$CONFIG_FILE
     fi
 
-    if [ -d "../zfs" ]; then
-        echo "CONFIG_ZFS=y" >>$CONFIG_FILE
-    fi
+    echo "CONFIG_ZFS=y" >>$CONFIG_FILE
 fi
 
 set -x


### PR DESCRIPTION
spl and zfs were not included in built in kernel builds
since the build_spl and build_zfs properties were preventing
the repositories from being cloned. Correct the BUILD build
factory to account for built in builds and only perform the
build process for spl and zfs if the current build is not
a built in build.

Signed-off-by: Giuseppe Di Natale <dinatale2@llnl.gov>