### PR TITLE
Install bison and flex on Amazon Linux

### DIFF
--- a/scripts/bb-dependencies.sh
+++ b/scripts/bb-dependencies.sh
@@ -14,7 +14,7 @@ set -x
 case "$BB_NAME" in
 Amazon*)
     # Required development tools.
-    sudo -E yum -y install gcc autoconf libtool gdb lcov
+    sudo -E yum -y install gcc autoconf libtool gdb lcov bison flex
 
     # Required utilities.
     sudo -E yum -y install git rpm-build wget curl bc fio acl sysstat \


### PR DESCRIPTION
The bison and flex packages are required by the Kernel Builders.

Signed-off-by: Giuseppe Di Natale <dinatale2@llnl.gov>