### PR TITLE
Replace Kernel.org builder with Fedora Rawhide

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -602,6 +602,7 @@ perf_factory.addStep(ShellCommand(command=["runurl", bb_url + "bb-cleanup.sh"],
 # ami-12240a72 - CentOS 7 07-12-2017 Mainline
 # ami-3b15285b - Debian 8 10-20-2017
 # ami-56dedd36 - Fedora 27 1-12-2018
+# ami-e20d0282 - Fedora Rawhide 2-2-2018
 # ami-57152837 - Ubuntu 14.04 10-20-2017
 # ami-601a2700 - Ubuntu 16.04 10-20-2017
 # ami-f2ddde92 - Ubuntu 17.04 1-12-2018 Coverage
@@ -631,13 +632,6 @@ release_slaves = \
     centos7_x86_64_release_slave
 
 # Distribution slaves
-kernel_default_x86_64_slave = [
-    ZFSEC2BuildSlave(
-        name="Amazon-KernelDefault-x86_64-buildslave%s" % (str(i+1)),
-        ami="ami-3c0d025c"
-    ) for i in range(0, numslaves)
-]
-
 kernel_builtin_x86_64_slave = [
     ZFSEC2BuildSlave(
         name="Amazon-KernelBuiltin-x86_64-buildslave%s" % (str(i+1)),
@@ -688,7 +682,6 @@ ubuntu16_x86_64_slave = [
 ]
 
 distro_slaves = \
-    kernel_default_x86_64_slave + \
     kernel_builtin_x86_64_slave + \
     debian8_x86_64_slave + \
     centos6_x86_64_slave + \
@@ -784,6 +777,13 @@ fedora27_x86_64_testslave = [
     ) for i in range(0, numtestslaves)
 ]
 
+fedoraRH_x86_64_testslave = [
+    ZFSEC2TestSlave(
+        name="Fedora-Rawhide-x86_64-testslave%s" % (str(i+1)),
+        ami="ami-e20d0282"
+    ) for i in range(0, numtestslaves)
+]
+
 ubuntu16_x86_64_testslave = [
     ZFSEC2TestSlave(
         name="Ubuntu-16.04-x86_64-testslave%s" % (str(i+1)),
@@ -804,6 +804,7 @@ test_slaves = \
     centos7_x86_64_testslave + \
     centos7_x86_64_ml_testslave + \
     fedora27_x86_64_testslave + \
+    fedoraRH_x86_64_testslave + \
     ubuntu16_x86_64_testslave + \
     ubuntu17_x86_64_testslave
 
@@ -949,21 +950,6 @@ builder_release_properties = {
     "checklint":     "no",
 }
 
-builder_linux_properties = {
-    "buildlinux":    "yes",
-    "buildlustre":   "no",
-    "buildspl":      "yes",
-    "buildzfs":      "yes",
-    "builtin":       "no",
-    "configlustre":  "",
-    "configspl":     "--enable-debug",
-    "configzfs":     "--enable-debug --enable-debuginfo",
-    "install":       "packages",
-    "repoowner":     "zfsonlinux",
-    "reponame":      "zfs",
-    "checklint":     "no",
-}
-
 builder_builtin_properties = {
     "buildlinux":    "yes",
     "buildlustre":   "no",
@@ -1099,13 +1085,6 @@ release_builders = [
 # Distro builders
 distro_builders = [
     ZFSBuilderConfig(
-        name="Kernel.org Default x86_64 (BUILD)",
-        factory=build_factory,
-        slavenames=[slave.name for slave in kernel_default_x86_64_slave],
-        tags=build_distro_tags,
-        properties=builder_linux_properties,
-    ),
-    ZFSBuilderConfig(
         name="Kernel.org Built-in x86_64 (BUILD)",
         factory=build_factory,
         slavenames=[slave.name for slave in kernel_builtin_x86_64_slave],
@@ -1238,6 +1217,13 @@ test_builders = [
         slavenames=[slave.name for slave in fedora27_x86_64_testslave],
         tags=test_tags,
         properties=builder_default_properties,
+    ),
+    ZFSBuilderConfig(
+        name="Fedora Rawhide x86_64 (TEST)",
+        factory=test_factory,
+        slavenames=[slave.name for slave in fedoraRH_x86_64_testslave],
+        tags=test_tags,
+        properties=builder_release_properties,
     ),
     ZFSBuilderConfig(
         name="Ubuntu 16.04 x86_64 (TEST)",

--- a/scripts/bb-dependencies.sh
+++ b/scripts/bb-dependencies.sh
@@ -93,7 +93,7 @@ Fedora*)
     sudo -E dnf -y install kernel-devel-$(uname -r) zlib-devel \
         libuuid-devel libblkid-devel libselinux-devel \
         xfsprogs-devel libattr-devel libacl-devel libudev-devel \
-        device-mapper-devel openssl-devel
+        device-mapper-devel openssl-devel libtirpc-devel
 
     sudo -E dnf -y install libasan python3
     ;;


### PR DESCRIPTION
Use the Fedora Rawhide release to perform testing on the latest
kernels.  By using these kernels which are built nightly we can
easily run the ZFS Test Suite against the latest kernels.

Additionally, this change ensures we're aware of and have time
to address and changes in the Fedora packaging guidelines before
the next version is officially released.

For the moment, non-debug packages must be built until all new
warnings from gcc 8 are resolved and the non-debug kernel is used.