### PR TITLE
Provide a summary log for zfstests step 

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -433,6 +433,8 @@ test_factory.addStep(ShellCommand(
     maxTime=28800, sigtermTime=30, logEnviron=False,
     lazylogfiles=True, timeout=4200,
     logfiles={"console"  : { "filename" : "console.log",  "follow" : False },
+              "summary"  : { "filename" : "summary.log",  "follow" : False },
+              "tests"    : { "filename" : "test.log",     "follow" : True },
               "log"      : { "filename" : "log",          "follow" : True },
               "kmemleak" : { "filename" : "kmemleak.log", "follow" : False }},
     decodeRC={0 : SUCCESS, 1 : FAILURE, 2 : WARNINGS, 3 : SKIPPED },


### PR DESCRIPTION
On the zfstests step of TEST builders, put the FAIL and
KILLED test cases into fail.log to make it easier to find
failures.

Signed-off-by: Giuseppe Di Natale <dinatale2@llnl.gov>