### PR TITLE
Fix Fedora Rawhide bootstrapping

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -604,7 +604,7 @@ perf_factory.addStep(ShellCommand(command=["runurl", bb_url + "bb-cleanup.sh"],
 # ami-12240a72 - CentOS 7 07-12-2017 Mainline
 # ami-3b15285b - Debian 8 10-20-2017
 # ami-56dedd36 - Fedora 27 1-12-2018
-# ami-e20d0282 - Fedora Rawhide 2-2-2018
+# ami-46a8a226 - Fedora Rawhide 3-6-2018
 # ami-31141a51 - Ubuntu 14.04 2-8-2018
 # ami-3e141a5e - Ubuntu 16.04 2-8-2018
 # ami-f2ddde92 - Ubuntu 17.04 1-12-2018 Coverage
@@ -782,7 +782,7 @@ fedora27_x86_64_testslave = [
 fedoraRH_x86_64_testslave = [
     ZFSEC2TestSlave(
         name="Fedora-Rawhide-x86_64-testslave%s" % (str(i+1)),
-        ami="ami-e20d0282"
+        ami="ami-46a8a226"
     ) for i in range(0, numtestslaves)
 ]
 

--- a/scripts/bb-bootstrap.sh
+++ b/scripts/bb-bootstrap.sh
@@ -210,6 +210,13 @@ Debian*)
     ;;
 
 Fedora*)
+    # As of Fedora 29 buildbot v1.0 is provided from the repository.  This
+    # version is incompatible v0.8 on master, so use the older pip version.
+    VERSION=$(cut -f3 -d' ' /etc/fedora-release)
+    if test $VERSION -ge 29; then
+        BB_USE_PIP=1
+    fi
+
     # Relying on the pip version of the buildslave is more portable but
     # slower to bootstrap.  By default prefer the packaged version.
     if test $BB_USE_PIP -ne 0; then


### PR DESCRIPTION
Fedora 29 will ship with buildbot v1.0 which is incompatible with
v0.8 which is used on the buildbot master.  Therefore, install the
buildbot-slave packages from pip which still provides the older
compatible verison.

This is at best a stop gap measure until we can move the buildbot
master forward to a newer version of buildbot.  Newer versions of
the master are apparently compatible with older slave versions.

Additionally update the Fedora Rawhide AMI.