### PR TITLE
User namespaces must be enabled for CentOS 7

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -598,10 +598,10 @@ perf_factory.addStep(ShellCommand(command=["runurl", bb_url + "bb-cleanup.sh"],
 #
 # AMI Reference:
 #
-# ami-3c0d025c - Amazon 2 2-2-2017
-# ami-ca2608aa - CentOS 6 07-12-2017
-# ami-4f27092f - CentOS 7 07-12-2017
-# ami-12240a72 - CentOS 7 07-12-2017 Mainline
+# ami-3c0d025c - Amazon 2 2-2-2018
+# ami-29a2a849 - CentOS 6 3-6-2018
+# ami-10afa570 - CentOS 7 3-6-2018
+# ami-6caca60c - CentOS 7 3-6-2018 Mainline
 # ami-3b15285b - Debian 8 10-20-2017
 # ami-56dedd36 - Fedora 27 1-12-2018
 # ami-e20d0282 - Fedora Rawhide 2-2-2018
@@ -626,7 +626,7 @@ numslaves = 1
 centos7_x86_64_release_slave = [
     ZFSEC2BuildSlave(
         name="CentOS-7-x86_64-release-buildslave%s" % (str(i+1)),
-        ami="ami-4f27092f"
+        ami="ami-10afa570"
     ) for i in range(0, numslaves)
 ]
 
@@ -658,14 +658,14 @@ fedora27_x86_64_slave = [
 centos6_x86_64_slave = [
     ZFSEC2BuildSlave(
         name="CentOS-6-x86_64-buildslave%s" % (str(i+1)),
-        ami="ami-ca2608aa"
+        ami="ami-29a2a849"
     ) for i in range(0, numslaves)
 ]
 
 centos7_x86_64_slave = [
     ZFSEC2BuildSlave(
         name="CentOS-7-x86_64-buildslave%s" % (str(i+1)),
-        ami="ami-4f27092f"
+        ami="ami-10afa570"
     ) for i in range(0, numslaves)
 ]
 
@@ -754,21 +754,21 @@ amazon_x86_64_testslave = [
 centos6_x86_64_testslave = [
     ZFSEC2TestSlave(
         name="CentOS-6-x86_64-testslave%s" % (str(i+1)),
-        ami="ami-ca2608aa"
+        ami="ami-29a2a849"
     ) for i in range(0, numtestslaves)
 ]
 
 centos7_x86_64_testslave = [
     ZFSEC2TestSlave(
         name="CentOS-7-x86_64-testslave%s" % (str(i+1)),
-        ami="ami-4f27092f"
+        ami="ami-10afa570"
     ) for i in range(0, numtestslaves)
 ]
 
 centos7_x86_64_ml_testslave = [
     ZFSEC2TestSlave(
         name="CentOS-7-x86_64-ml-testslave%s" % (str(i+1)),
-        ami="ami-12240a72"
+        ami="ami-6caca60c"
     ) for i in range(0, numtestslaves)
 ]
 

--- a/scripts/bb-bootstrap.sh
+++ b/scripts/bb-bootstrap.sh
@@ -156,6 +156,15 @@ CentOS*)
     # Install the latest kernel to reboot on to.
     if test "$BB_MODE" = "TEST" -o "$BB_MODE" = "PERF"; then
         yum -y update kernel
+
+        # User namespaces must be enabled at boot time for CentOS 7
+        if cat /etc/redhat-release | grep -Eq "7."; then
+            grubby --args="user_namespace.enable=1" \
+                --update-kernel="$(grubby --default-kernel)"
+            grubby --args="namespace.unpriv_enable=1" \
+                --update-kernel="$(grubby --default-kernel)"
+            echo "user.max_user_namespaces=3883" > /etc/sysctl.d/99-userns.conf
+        fi
     fi
 
     # Use the debug kernel instead if indicated


### PR DESCRIPTION
User namespaces must be enabled for CentOS 7
    
https://discuss.linuxcontainers.org/t/lxd-on-centos-7/1250
    
Additionally update the CentOS AMIs to ensure all required packages are up to date.