### PR TITLE
Introduce Nightly Builds

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -7,6 +7,7 @@ from password import *
 from buildslaves import *
 from buildbot.buildslave import BuildSlave
 from buildbot.plugins import util
+from buildbot.schedulers.timed import Nightly
 
 bb_slave_port = 9989
 bb_try_port = 8033
@@ -1473,6 +1474,12 @@ default_codebases = {
     'spl'   : {'repository': spl_repo, 'branch': 'master', 'revision': None},
     'zfs'   : {'repository': zfs_repo, 'branch': 'master', 'revision': None} }
 
+release_7_codebases = {
+    'spl' :
+        {'repository': spl_repo, 'branch': 'spl-0.7-release', 'revision': None},
+    'zfs' :
+        {'repository': zfs_repo, 'branch': 'zfs-0.7-release', 'revision': None}}
+
 class CustomSingleBranchScheduler(SingleBranchScheduler):
     spl_pull_request = None
     zfs_branch = None
@@ -1504,6 +1511,24 @@ class CustomSingleBranchScheduler(SingleBranchScheduler):
                     ss['branch'] = 'spl-%s' % (m.group(1))
 
         return ss
+
+# This is a scheduler to build master nightly
+c['schedulers'].append(Nightly(
+    name="nightly-master-branch-scheduler",
+    builderNames=test_builders,
+    branch=None,
+    codebases=default_codebases,
+    onlyIfChanged=False,
+    hour=19, minute=0))
+
+# This is a scheduler to build 0.7 release nightly
+c['schedulers'].append(Nightly(
+    name="weekly-release-branch-scheduler",
+    builderNames=test_builders,
+    branch=None,
+    codebases=release_7_codebases,
+    onlyIfChanged=False,
+    dayOfWeek=6, hour=19, minute=0))
 
 # This scheduler is for pull requests.
 c['schedulers'].append(CustomSingleBranchScheduler(


### PR DESCRIPTION
In order to generate data regarding what ZTS tests are regularly failing, let’s begin running nightly builds to seed the known issues page.