### PR TITLE
Add installation of fio for zfs-test dependency for CentOS/RHEL

### DIFF
--- a/scripts/bb-dependencies.sh
+++ b/scripts/bb-dependencies.sh
@@ -73,8 +73,8 @@ CentOS*)
         sudo -E yum -y install libasan
     fi
 
-    # Testing support libraries
-    sudo -E yum -y install --enablerepo=epel python34
+    # Testing support libraries and tools
+    sudo -E yum -y install --enablerepo=epel python34 fio
     ;;
 
 Debian*)
@@ -152,8 +152,8 @@ RHEL*)
         sudo -E yum -y install libasan
     fi
 
-    # Testing support libraries
-    sudo -E yum -y install --enablerepo=epel python34
+    # Testing support libraries and tools
+    sudo -E yum -y install --enablerepo=epel python34 fio
     ;;
 
 SUSE*)


### PR DESCRIPTION
The `zfs-test` package is installed as part of the testing of zfs.

However, for CentOS/RHEL, it fails to install because `fio` is part of EPEL rather than the core distribution. We'll install it ahead of time so that it will be satisfied when it gets there.

Signed-off-by: Neal Gompa <ngompa@datto.com>