### PR TITLE
Install libyaml-devel as a dependency

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -1480,7 +1480,7 @@ c['schedulers'] = []
 
 default_codebases = {
     'linux' : {'repository': linux_repo, 'branch': 'master', 'revision': None},
-    'lustre': {'repository': lustre_repo, 'branch': 'b2_10', 'revision': None},
+    'lustre': {'repository': lustre_repo, 'branch': 'b2_11', 'revision': None},
     'spl'   : {'repository': spl_repo, 'branch': 'master', 'revision': None},
     'zfs'   : {'repository': zfs_repo, 'branch': 'master', 'revision': None} }
 

--- a/scripts/bb-dependencies.sh
+++ b/scripts/bb-dependencies.sh
@@ -77,7 +77,7 @@ CentOS*)
         zlib-devel libuuid-devel libblkid-devel libselinux-devel \
         xfsprogs-devel libattr-devel libacl-devel libudev-devel \
         device-mapper-devel openssl-devel libffi-devel python-devel \
-        libaio-devel python-setuptools python-cffi
+        libaio-devel python-setuptools python-cffi libyaml-devel
 
     # Packages that are version dependent and not always available
     if cat /etc/centos-release | grep -Fq 7.; then


### PR DESCRIPTION
Lustre 2.11 now requires libyaml-devel to build. Install
it as a dependency on CentOS for the Release builder.

Signed-off-by: Giuseppe Di Natale <dinatale2@llnl.gov>