### PR TITLE
Allow periods in valid 'Requires-spl' statements

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -1495,7 +1495,7 @@ class CustomSingleBranchScheduler(SingleBranchScheduler):
     zfs_branch = None
 
     def gotChange(self, change, important):
-        pattern = '^Requires-spl:\s*([a-zA-Z0-9_\-\:\/\+]+)'
+        pattern = '^Requires-spl:\s*([a-zA-Z0-9_\-\.\:\/\+]+)'
         m = re.search(pattern, change.comments, re.I | re.M)
         if m is not None:
             self.spl_pull_request = m.group(1)


### PR DESCRIPTION
When refs have periods in them, the regex match would make it stop at the period, which can cause unexpected issues. As periods are perfectly valid in branch names, they should be allowed.

Signed-off-by: Neal Gompa <ngompa@datto.com>