### PR TITLE
Use apt-get install return code in bb-dependencies

### DIFF
--- a/scripts/bb-dependencies.sh
+++ b/scripts/bb-dependencies.sh
@@ -12,12 +12,15 @@ fi
 # a function to wait for an apt-get upgrade to finish
 function apt-get-install
 {
-    echo "Waiting for other software managers to finish..."
-    while fuser /var/lib/dpkg/lock >/dev/null 2>&1 ; do
+    while true; do
+        sudo -E apt-get --yes install "$@"
+
+        # error code 11 indicates that a lock file couldn't be obtained
+        # keep retrying until we don't see an error code of 11
+        [[ $? -ne 11 ]] && break
+
         sleep 0.5
     done 
-
-    sudo -E apt-get --yes install "$@"
 }
 
 set -x


### PR DESCRIPTION
Use apt-get install return code to determine if buildbot
should retry package installation. Error code 11 indicates
that a lock file couldn't be obtained to install packages,
retry in those cases.

Signed-off-by: Giuseppe Di Natale <dinatale2@llnl.gov>