### PR TITLE
Introduce an override for kernel built

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -1466,6 +1466,7 @@ from buildbot.schedulers.trysched import Try_Userpass
 from buildbot.schedulers.basic import SingleBranchScheduler
 from buildbot.changes.filter import ChangeFilter
 from buildbot.changes import filter
+import os.path
 import copy
 
 style_builders = [builder.name for builder in style_builders]
@@ -1519,6 +1520,15 @@ class CustomSingleBranchScheduler(SingleBranchScheduler):
                 m = re.search(branch_pattern, self.zfs_branch, re.I | re.M)
                 if m is not None:
                     ss['branch'] = 'spl-%s' % (m.group(1))
+        elif codebase == "linux":
+            tag_override = None
+            if os.path.isfile('kernel.tag'):
+                with open('kernel.tag', 'r') as f:
+                    tag_override = f.readline()
+
+            if tag_override:
+                ss['branch'] = tag_override.strip()
+                ss['revision'] = None
 
         return ss
 


### PR DESCRIPTION
The Kernel Builders often fail to build because
new patches have been introduced in the upstream linux
kernel. The builders will often fail builds for quite
some time which defeats the purpose. Introduce a method
to override which tag we want to build while build issues
from the linux kernel's master branch are resolved.

The tag can be specified in the `kernel.tag` file within
the build master's working directory.

Signed-off-by: Giuseppe Di Natale <dinatale2@llnl.gov>