### PR TITLE
Add back dropped default setting for price_multiplier

### DIFF
--- a/master/buildslaves.py
+++ b/master/buildslaves.py
@@ -119,7 +119,8 @@ runurl $BB_URL/bb-bootstrap.sh
                 subnet_id=None, security_group_ids=None,
                 user_data=None, region="us-west-1", placement='a', max_builds=1,
                 build_wait_timeout=60, spot_instance=False, max_spot_price=0.10,
-                missing_timeout=60 * 20, block_device_map=None, **kwargs):
+                price_multiplier=None, missing_timeout=60 * 20,
+                block_device_map=None, **kwargs):
 
         self.name = name
         bin_path = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
@@ -180,9 +181,9 @@ runurl $BB_URL/bb-bootstrap.sh
             user_data=user_data, keypair_name=keypair_name, security_name=security_name,
             subnet_id=subnet_id, security_group_ids=security_group_ids,
             max_builds=max_builds, spot_instance=spot_instance, tags=tags,
-            max_spot_price=max_spot_price, placement=placement,
+            max_spot_price=max_spot_price, price_multiplier=price_multiplier,
             build_wait_timeout=build_wait_timeout, missing_timeout=missing_timeout,
-            block_device_map=block_device_map, **kwargs)
+            placement=placement, block_device_map=block_device_map, **kwargs)
 
 class ZFSEC2StyleSlave(ZFSEC2Slave):
     def __init__(self, name, **kwargs):

--- a/master/patches/0001-Treat-RETRY-as-FAILURE.patch
+++ b/master/patches/0001-Treat-RETRY-as-FAILURE.patch
@@ -1,4 +1,4 @@
-From aeb26b2d3cb548736bf73f31da7b9e3b0ca21455 Mon Sep 17 00:00:00 2001
+From a09450c1c5fb08acf1cf8944ed84af3fd0ac6785 Mon Sep 17 00:00:00 2001
 From: Brian Behlendorf <behlendorf1@llnl.gov>
 Date: Thu, 3 Dec 2015 10:27:24 -0800
 Subject: [PATCH 01/18] Treat RETRY as FAILURE
@@ -34,5 +34,5 @@ index fc720d924..e0e3ffacd 100644
  
          # if we skipped this step, then don't adjust the build status
 -- 
-2.13.6
+2.14.3
 

--- a/master/patches/0002-Add-isIdle-helper.patch
+++ b/master/patches/0002-Add-isIdle-helper.patch
@@ -1,4 +1,4 @@
-From 6af327f2aa17e24cf4e2f38754b676157b24a0a5 Mon Sep 17 00:00:00 2001
+From b242612cbc4f4830c693a45f2ad5490856e8b352 Mon Sep 17 00:00:00 2001
 From: Brian Behlendorf <behlendorf1@llnl.gov>
 Date: Tue, 3 Nov 2015 11:04:10 -0800
 Subject: [PATCH 02/18] Add isIdle helper
@@ -28,5 +28,5 @@ index 86f427d3c..42f050e5b 100644
          return self.state not in (IDLE, LATENT)
  
 -- 
-2.13.6
+2.14.3
 

--- a/master/patches/0003-Set-tags-for-latent-ec2-buildslaves.patch
+++ b/master/patches/0003-Set-tags-for-latent-ec2-buildslaves.patch
@@ -1,4 +1,4 @@
-From 1a9a091852b7961713d14a494dbf76a0f4167277 Mon Sep 17 00:00:00 2001
+From e6a80f20b7917dafe0e11fa43a575a2d3bb0f953 Mon Sep 17 00:00:00 2001
 From: Brian Behlendorf <behlendorf1@llnl.gov>
 Date: Thu, 3 Dec 2015 10:37:06 -0800
 Subject: [PATCH 03/18] Set tags for latent ec2 buildslaves
@@ -35,5 +35,5 @@ index 191999ea6..e16b6372b 100644
          else:
              return None, None, None
 -- 
-2.13.6
+2.14.3
 

--- a/master/patches/0004-Retry-on-EC2-NotFound-errors.patch
+++ b/master/patches/0004-Retry-on-EC2-NotFound-errors.patch
@@ -1,4 +1,4 @@
-From c96091293fb3c91de0b11f4349e2d3341903fe6a Mon Sep 17 00:00:00 2001
+From a39b26825cb078c1a8402b0d8c2d96330cc0cc7e Mon Sep 17 00:00:00 2001
 From: Brian Behlendorf <behlendorf1@llnl.gov>
 Date: Thu, 3 Dec 2015 11:15:43 -0800
 Subject: [PATCH 04/18] Retry on EC2 'NotFound' errors
@@ -128,5 +128,5 @@ index e16b6372b..ae40cf181 100644
              minutes = duration // 60
              seconds = duration % 60
 -- 
-2.13.6
+2.14.3
 

--- a/master/patches/0005-Soft-disconnect-when-build_wait_timeout-0.patch
+++ b/master/patches/0005-Soft-disconnect-when-build_wait_timeout-0.patch
@@ -1,4 +1,4 @@
-From fc2c9c94ff5badd690a9c7e13e8635fbdeea2970 Mon Sep 17 00:00:00 2001
+From 85132f84526add0248459ad78ea1136f4de2bd51 Mon Sep 17 00:00:00 2001
 From: Brian Behlendorf <behlendorf1@llnl.gov>
 Date: Thu, 3 Dec 2015 12:47:08 -0800
 Subject: [PATCH 05/18] Soft disconnect when 'build_wait_timeout==0'
@@ -32,5 +32,5 @@ index 07c077b35..c28cf5043 100644
                  # this will cause the slave to re-substantiate immediately if
                  # there are pending build requests.
 -- 
-2.13.6
+2.14.3
 

--- a/master/patches/0006-Force-root-volumes-to-be-deleted-upon-termination-on.patch
+++ b/master/patches/0006-Force-root-volumes-to-be-deleted-upon-termination-on.patch
@@ -1,4 +1,4 @@
-From 64f174c76000d42395c28e608479d60c90aa1db7 Mon Sep 17 00:00:00 2001
+From 21fd70b3a905797542a36299da5c699a20c906bb Mon Sep 17 00:00:00 2001
 From: Brian Behlendorf <behlendorf1@llnl.gov>
 Date: Thu, 25 Feb 2016 09:16:47 -0800
 Subject: [PATCH 06/18] Force root volumes to be deleted upon termination on
@@ -83,5 +83,5 @@ index ae40cf181..00ead8a5d 100644
                  self.conn.create_tags(self.instance.id, self.tags)
              return self.instance.id, image.id, start_time
 -- 
-2.13.6
+2.14.3
 

--- a/master/patches/0007-Create-volumes.patch
+++ b/master/patches/0007-Create-volumes.patch
@@ -1,17 +1,17 @@
-From 07f6a396081626b5aebf52fd2018fd255d61d802 Mon Sep 17 00:00:00 2001
+From 4b4dbca300f6f58be60d7e398fd41ccdb2ad20de Mon Sep 17 00:00:00 2001
 From: Brian Behlendorf <behlendorf1@llnl.gov>
 Date: Mon, 7 Mar 2016 14:13:11 -0800
-Subject: [PATCH 10/18] Create volumes
+Subject: [PATCH 07/18] Create volumes
 
 ---
  master/buildbot/buildslave/ec2.py | 45 ++++++++++++++++++++++++++++++++++++---
  1 file changed, 42 insertions(+), 3 deletions(-)
 
 diff --git a/master/buildbot/buildslave/ec2.py b/master/buildbot/buildslave/ec2.py
-index bc7926547..8f83ec3d8 100644
+index 00ead8a5d..d787f194f 100644
 --- a/master/buildbot/buildslave/ec2.py
 +++ b/master/buildbot/buildslave/ec2.py
-@@ -46,6 +46,12 @@ SPOT_REQUEST_PENDING_STATES = ['pending-evaluation', 'pending-fulfillment']
+@@ -44,6 +44,12 @@ SPOT_REQUEST_PENDING_STATES = ['pending-evaluation', 'pending-fulfillment']
  FULFILLED = 'fulfilled'
  PRICE_TOO_LOW = 'price-too-low'
  
@@ -24,16 +24,16 @@ index bc7926547..8f83ec3d8 100644
  
  class EC2LatentBuildSlave(AbstractLatentBuildSlave):
  
-@@ -64,7 +70,7 @@ class EC2LatentBuildSlave(AbstractLatentBuildSlave):
+@@ -61,7 +67,7 @@ class EC2LatentBuildSlave(AbstractLatentBuildSlave):
                   build_wait_timeout=60 * 10, properties={}, locks=None,
                   spot_instance=False, max_spot_price=1.6, volumes=[],
                   placement=None, price_multiplier=1.2, tags={},
--                 delete_vol_term=True, block_device_map=None):
-+                 delete_vol_term=True, create_volumes=[],block_device_map=None):
+-                 delete_vol_term=True):
++                 delete_vol_term=True, create_volumes=[]):
  
          AbstractLatentBuildSlave.__init__(
              self, name, password, max_builds, notify_on_missing,
-@@ -113,6 +119,7 @@ class EC2LatentBuildSlave(AbstractLatentBuildSlave):
+@@ -100,6 +106,7 @@ class EC2LatentBuildSlave(AbstractLatentBuildSlave):
          self.volumes = volumes
          self.price_multiplier = price_multiplier
          self.delete_vol_term = delete_vol_term
@@ -41,7 +41,7 @@ index bc7926547..8f83ec3d8 100644
  
          if None not in [placement, region]:
              self.placement = '%s%s' % (region, placement)
-@@ -335,8 +342,8 @@ class EC2LatentBuildSlave(AbstractLatentBuildSlave):
+@@ -301,8 +308,8 @@ class EC2LatentBuildSlave(AbstractLatentBuildSlave):
          if self.delete_vol_term is False:
              return
  
@@ -52,7 +52,7 @@ index bc7926547..8f83ec3d8 100644
  
          del_on_term = []
          for devname in block_map['blockDeviceMapping']:
-@@ -347,6 +354,31 @@ class EC2LatentBuildSlave(AbstractLatentBuildSlave):
+@@ -313,6 +320,31 @@ class EC2LatentBuildSlave(AbstractLatentBuildSlave):
              if not self.conn.modify_instance_attribute(self.instance.id, 'blockDeviceMapping', del_on_term):
                  log.msg("Failed to set deletion on termination")
  
@@ -84,7 +84,7 @@ index bc7926547..8f83ec3d8 100644
      def _attach_volumes(self):
          for volume_id, device_node in self.volumes:
              self.conn.attach_volume(volume_id, self.instance.id, device_node)
-@@ -354,11 +386,18 @@ class EC2LatentBuildSlave(AbstractLatentBuildSlave):
+@@ -320,11 +352,18 @@ class EC2LatentBuildSlave(AbstractLatentBuildSlave):
                      (volume_id, device_node))
  
      def _handle_volumes(self):
@@ -104,5 +104,5 @@ index bc7926547..8f83ec3d8 100644
          if self.elastic_ip is not None:
              self.conn.disassociate_address(self.elastic_ip.public_ip)
 -- 
-2.13.6
+2.14.3
 

--- a/master/patches/0008-Allow-slaves-to-substantiate-in-parallel.patch
+++ b/master/patches/0008-Allow-slaves-to-substantiate-in-parallel.patch
@@ -1,7 +1,7 @@
-From cdf5b8190a931c9cff7b4eefd4e19f6eab002408 Mon Sep 17 00:00:00 2001
+From ecdac0b8ecdf4695d7118366ef1186508da10c72 Mon Sep 17 00:00:00 2001
 From: "Christopher J. Morrone" <morrone2@llnl.gov>
 Date: Thu, 21 Apr 2016 02:39:36 +0000
-Subject: [PATCH 11/18] Allow slaves to substantiate in parallel
+Subject: [PATCH 08/18] Allow slaves to substantiate in parallel
 
 BuildRequestDistributor's _maybeStartBuildsOnBuilder() method is
 decorated with @defer.inlineCallbacks.  This means that when it
@@ -48,5 +48,5 @@ index 2848510ab..a6d88cee0 100644
      def createBuildChooser(self, bldr, master):
          # just instantiate the build chooser requested
 -- 
-2.13.6
+2.14.3
 

--- a/master/patches/0009-Move-spot-price-historical-averaging-to-its-own-func.patch
+++ b/master/patches/0009-Move-spot-price-historical-averaging-to-its-own-func.patch
@@ -1,7 +1,7 @@
-From 2e7c981ae932ac9803a8933a491118b538491bce Mon Sep 17 00:00:00 2001
+From 14b9ecba56ce3f673aca2b85f006292978261a76 Mon Sep 17 00:00:00 2001
 From: "Christopher J. Morrone" <morrone2@llnl.gov>
 Date: Thu, 9 Jun 2016 15:03:07 -0700
-Subject: [PATCH 14/18] Move spot price historical averaging to its own
+Subject: [PATCH 09/18] Move spot price historical averaging to its own
  function
 
 ---
@@ -9,10 +9,10 @@ Subject: [PATCH 14/18] Move spot price historical averaging to its own
  1 file changed, 5 insertions(+), 1 deletion(-)
 
 diff --git a/master/buildbot/buildslave/ec2.py b/master/buildbot/buildslave/ec2.py
-index 8f83ec3d8..42803f83d 100644
+index d787f194f..3c77804f5 100644
 --- a/master/buildbot/buildslave/ec2.py
 +++ b/master/buildbot/buildslave/ec2.py
-@@ -435,7 +435,7 @@ class EC2LatentBuildSlave(AbstractLatentBuildSlave):
+@@ -401,7 +401,7 @@ class EC2LatentBuildSlave(AbstractLatentBuildSlave):
                  (self.__class__.__name__, self.slavename,
                   instance.id, goal, duration // 60, duration % 60))
  
@@ -21,7 +21,7 @@ index 8f83ec3d8..42803f83d 100644
          timestamp_yesterday = time.gmtime(int(time.time() - 86400))
          spot_history_starttime = time.strftime(
              '%Y-%m-%dT%H:%M:%SZ', timestamp_yesterday)
-@@ -453,6 +453,10 @@ class EC2LatentBuildSlave(AbstractLatentBuildSlave):
+@@ -419,6 +419,10 @@ class EC2LatentBuildSlave(AbstractLatentBuildSlave):
              target_price = 0.02
          else:
              target_price = (price_sum / price_count) * self.price_multiplier
@@ -33,5 +33,5 @@ index 8f83ec3d8..42803f83d 100644
              log.msg('%s %s calculated spot price %0.2f exceeds '
                      'configured maximum of %0.2f' %
 -- 
-2.13.6
+2.14.3
 

--- a/master/patches/0010-Allow-independant-EC2-price_multiplier-or-max_spot_p.patch
+++ b/master/patches/0010-Allow-independant-EC2-price_multiplier-or-max_spot_p.patch
@@ -1,7 +1,7 @@
-From a228400903322db5be47ea3c54cb4c8152c0e3ee Mon Sep 17 00:00:00 2001
+From 8b6f056e6505554c3725f48077c3046ec2375ec3 Mon Sep 17 00:00:00 2001
 From: "Christopher J. Morrone" <morrone2@llnl.gov>
 Date: Tue, 7 Jun 2016 13:51:41 -0700
-Subject: [PATCH 15/18] Allow independant EC2 price_multiplier or
+Subject: [PATCH 10/18] Allow independant EC2 price_multiplier or
  max_spot_price usage
 
 Change the EC2LatentBuildSlave to allow the use of just one
@@ -28,25 +28,26 @@ to substantiate with the max_spot_price.
 
 Fixes #2898 problems 1 and 3.
 ---
- master/buildbot/buildslave/ec2.py      | 28 +++++++++++++++-------------
+ master/buildbot/buildslave/ec2.py      | 29 ++++++++++++++++-------------
  master/docs/manual/cfg-buildslaves.rst |  5 +++++
- 2 files changed, 20 insertions(+), 13 deletions(-)
+ 2 files changed, 21 insertions(+), 13 deletions(-)
 
 diff --git a/master/buildbot/buildslave/ec2.py b/master/buildbot/buildslave/ec2.py
-index 42803f83d..f1a85d383 100644
+index 3c77804f5..1e8442e9e 100644
 --- a/master/buildbot/buildslave/ec2.py
 +++ b/master/buildbot/buildslave/ec2.py
-@@ -108,6 +108,9 @@ class EC2LatentBuildSlave(AbstractLatentBuildSlave):
-         if security_name is None and not subnet_id:
-             security_name = 'latent_buildbot_slave'
-             log.msg('Using default keypair name, since none is set')
+@@ -95,6 +95,10 @@ class EC2LatentBuildSlave(AbstractLatentBuildSlave):
+             else:
+                 # verify that regex will compile
+                 re.compile(valid_ami_location_regex)
 +        if spot_instance and price_multiplier is None and max_spot_price is None:
 +            raise ValueError('You must provide either one, or both, of '
 +                             'price_multiplier or max_spot_price')
++
          self.valid_ami_owners = valid_ami_owners
          self.valid_ami_location_regex = valid_ami_location_regex
          self.instance_type = instance_type
-@@ -450,24 +453,23 @@ class EC2LatentBuildSlave(AbstractLatentBuildSlave):
+@@ -416,24 +420,23 @@ class EC2LatentBuildSlave(AbstractLatentBuildSlave):
                  price_sum += price.price
                  price_count += 1
          if price_count == 0:
@@ -80,14 +81,14 @@ index 42803f83d..f1a85d383 100644
          reservations = self.conn.request_spot_instances(
 -            target_price, self.ami, key_name=self.keypair_name,
 +            bid_price, self.ami, key_name=self.keypair_name,
-             security_groups=self.classic_security_groups,
+             security_groups=[
+                 self.security_name],
              instance_type=self.instance_type,
-             user_data=self.user_data,
 diff --git a/master/docs/manual/cfg-buildslaves.rst b/master/docs/manual/cfg-buildslaves.rst
-index a468a73a7..2ead58acc 100644
+index d8ddd1884..ef70c3fb2 100644
 --- a/master/docs/manual/cfg-buildslaves.rst
 +++ b/master/docs/manual/cfg-buildslaves.rst
-@@ -416,6 +416,11 @@ Additionally, you may want to specify ``max_spot_price`` and ``price_multiplier`
+@@ -372,6 +372,11 @@ Additionally, you may want to specify ``max_spot_price`` and ``price_multiplier`
  This example would attempt to create a m1.large spot instance in the us-west-2b region costing no more than $0.09/hour.
  The spot prices for that region in the last 24 hours will be averaged and multiplied by the ``price_multiplier`` parameter, then a spot request will be sent to Amazon with the above details.
  If the spot request is rejected, an error message will be logged with the final status.
@@ -100,5 +101,5 @@ index a468a73a7..2ead58acc 100644
  .. index::
     libvirt
 -- 
-2.13.6
+2.14.3
 

--- a/master/patches/0011-Properly-handle-a-stale-broker-connection-on-ping.patch
+++ b/master/patches/0011-Properly-handle-a-stale-broker-connection-on-ping.patch
@@ -1,7 +1,7 @@
-From fba21596ee6726056c80147861a177816a4c4142 Mon Sep 17 00:00:00 2001
-From: Cloud User <ec2-user@ip-172-31-18-165.eu-central-1.compute.internal>
+From aa80ab9b1cf702bd6376962ff072836262e4e222 Mon Sep 17 00:00:00 2001
+From: Giuseppe Di Natale <dinatale2@llnl.gov>
 Date: Fri, 1 Jul 2016 17:00:10 +0000
-Subject: [PATCH 12/18] Properly handle a stale broker connection on ping
+Subject: [PATCH 11/18] Properly handle a stale broker connection on ping
 
 When a slave is pinged, it is possible for the underlying
 broker connection to be stale. callRemote in that case, will
@@ -97,5 +97,5 @@ index 42f050e5b..0866720a3 100644
  
      def _pong(self, res):
 -- 
-2.13.6
+2.14.3
 

--- a/master/patches/0012-Add-debug-logging.patch
+++ b/master/patches/0012-Add-debug-logging.patch
@@ -1,7 +1,7 @@
-From dcc951a3db303db09309db889bf122c9e5bc856f Mon Sep 17 00:00:00 2001
+From 7ff371cb809d122b57bf1d4c108ebbe70d492862 Mon Sep 17 00:00:00 2001
 From: Brian Behlendorf <behlendorf1@llnl.gov>
 Date: Tue, 19 Jul 2016 15:55:52 -0700
-Subject: [PATCH 13/18] Add debug logging
+Subject: [PATCH 12/18] Add debug logging
 
 ---
  master/buildbot/buildslave/base.py | 3 +++
@@ -41,5 +41,5 @@ index 112b5c105..ff8480c72 100644
          if len(self.config.env) > 0:
              build.setSlaveEnvironment(self.config.env)
 -- 
-2.13.6
+2.14.3
 

--- a/master/patches/0013-Add-instance-id-to-build-properties.patch
+++ b/master/patches/0013-Add-instance-id-to-build-properties.patch
@@ -1,7 +1,7 @@
-From 8a257b411ae30a08872bbf531ac81e1170950ab9 Mon Sep 17 00:00:00 2001
+From 222b228779ad4625cc2bd104f451a968ea2f3651 Mon Sep 17 00:00:00 2001
 From: Brian Behlendorf <behlendorf1@llnl.gov>
 Date: Wed, 20 Jul 2016 10:58:38 -0700
-Subject: [PATCH 16/18] Add instance id to build properties
+Subject: [PATCH 13/18] Add instance id to build properties
 
 Signed-off-by: Brian Behlendorf <behlendorf1@llnl.gov>
 ---
@@ -9,10 +9,10 @@ Signed-off-by: Brian Behlendorf <behlendorf1@llnl.gov>
  1 file changed, 1 insertion(+)
 
 diff --git a/master/buildbot/buildslave/ec2.py b/master/buildbot/buildslave/ec2.py
-index f1a85d383..b81c13754 100644
+index 1e8442e9e..9f24df51d 100644
 --- a/master/buildbot/buildslave/ec2.py
 +++ b/master/buildbot/buildslave/ec2.py
-@@ -506,6 +506,7 @@ class EC2LatentBuildSlave(AbstractLatentBuildSlave):
+@@ -471,6 +471,7 @@ class EC2LatentBuildSlave(AbstractLatentBuildSlave):
                  else:
                      raise
          if self.instance.state == RUNNING:
@@ -21,5 +21,5 @@ index f1a85d383..b81c13754 100644
              minutes = duration // 60
              seconds = duration % 60
 -- 
-2.13.6
+2.14.3
 

--- a/master/patches/0014-Remove-default-values-for-keypair-and-security-names.patch
+++ b/master/patches/0014-Remove-default-values-for-keypair-and-security-names.patch
@@ -1,7 +1,7 @@
-From 3c87a6e4d009dd8cb8f66bd1d263d5e323b2f3b2 Mon Sep 17 00:00:00 2001
+From b7051bc715c0f8943c281418b22625f5d622f5cf Mon Sep 17 00:00:00 2001
 From: Neal Gompa <ngompa@datto.com>
 Date: Fri, 30 Mar 2018 17:01:14 -0400
-Subject: [PATCH 07/18] Remove default values for keypair and security names
+Subject: [PATCH 14/18] Remove default values for keypair and security names
  for EC2LatentBuildSlave
 
 This is a simpler/trivial adaptation of 68a9267d5fff06e0ff7c6ea8a82ab66fcf6a359c in buildbot 0.9.x,
@@ -11,14 +11,14 @@ There are no test adaptations for this, as ultimate behavior has not yet changed
 
 Signed-off-by: Neal Gompa <ngompa@datto.com>
 ---
- master/buildbot/buildslave/ec2.py | 10 ++++++++--
- 1 file changed, 8 insertions(+), 2 deletions(-)
+ master/buildbot/buildslave/ec2.py | 11 ++++++++---
+ 1 file changed, 8 insertions(+), 3 deletions(-)
 
 diff --git a/master/buildbot/buildslave/ec2.py b/master/buildbot/buildslave/ec2.py
-index 00ead8a5d..622bcc973 100644
+index 9f24df51d..780c4ef05 100644
 --- a/master/buildbot/buildslave/ec2.py
 +++ b/master/buildbot/buildslave/ec2.py
-@@ -55,8 +55,8 @@ class EC2LatentBuildSlave(AbstractLatentBuildSlave):
+@@ -61,8 +61,8 @@ class EC2LatentBuildSlave(AbstractLatentBuildSlave):
                   valid_ami_owners=None, valid_ami_location_regex=None,
                   elastic_ip=None, identifier=None, secret_identifier=None,
                   aws_id_file_path=None, user_data=None, region=None,
@@ -29,7 +29,7 @@ index 00ead8a5d..622bcc973 100644
                   max_builds=None, notify_on_missing=[], missing_timeout=60 * 20,
                   build_wait_timeout=60 * 10, properties={}, locks=None,
                   spot_instance=False, max_spot_price=1.6, volumes=[],
-@@ -89,6 +89,12 @@ class EC2LatentBuildSlave(AbstractLatentBuildSlave):
+@@ -95,10 +95,15 @@ class EC2LatentBuildSlave(AbstractLatentBuildSlave):
              else:
                  # verify that regex will compile
                  re.compile(valid_ami_location_regex)
@@ -39,9 +39,13 @@ index 00ead8a5d..622bcc973 100644
 +        if security_name is None:
 +            security_name = 'latent_buildbot_slave'
 +            log.msg('Using default keypair name, since none is set')
+         if spot_instance and price_multiplier is None and max_spot_price is None:
+             raise ValueError('You must provide either one, or both, of '
+                              'price_multiplier or max_spot_price')
+-
          self.valid_ami_owners = valid_ami_owners
          self.valid_ami_location_regex = valid_ami_location_regex
          self.instance_type = instance_type
 -- 
-2.13.6
+2.14.3
 

--- a/master/patches/0015-Add-VPC-support-to-EC2LatentBuildSlave.patch
+++ b/master/patches/0015-Add-VPC-support-to-EC2LatentBuildSlave.patch
@@ -1,7 +1,7 @@
-From fb17b8cdde0df115e96e40422b4a484ec8b48601 Mon Sep 17 00:00:00 2001
+From b46f111bd8cf962cf691c12316eb8ebff4747c8f Mon Sep 17 00:00:00 2001
 From: Neal Gompa <ngompa@datto.com>
 Date: Fri, 30 Mar 2018 17:23:54 -0400
-Subject: [PATCH 08/18] Add VPC support to EC2LatentBuildSlave
+Subject: [PATCH 15/18] Add VPC support to EC2LatentBuildSlave
 
 Partially adapted from 8b67f91b50d72979ff620413dc4169d277b519df in buildbot 0.9.x,
 originally authored by Ryan Sydnor <ryan.t.sydnor@gmail.com>.
@@ -17,10 +17,10 @@ Signed-off-by: Neal Gompa <ngompa@datto.com>
  3 files changed, 101 insertions(+), 23 deletions(-)
 
 diff --git a/master/buildbot/buildslave/ec2.py b/master/buildbot/buildslave/ec2.py
-index 622bcc973..154c06bd3 100644
+index 780c4ef05..dd111e283 100644
 --- a/master/buildbot/buildslave/ec2.py
 +++ b/master/buildbot/buildslave/ec2.py
-@@ -57,6 +57,7 @@ class EC2LatentBuildSlave(AbstractLatentBuildSlave):
+@@ -63,6 +63,7 @@ class EC2LatentBuildSlave(AbstractLatentBuildSlave):
                   aws_id_file_path=None, user_data=None, region=None,
                   keypair_name=None,
                   security_name=None,
@@ -28,7 +28,7 @@ index 622bcc973..154c06bd3 100644
                   max_builds=None, notify_on_missing=[], missing_timeout=60 * 20,
                   build_wait_timeout=60 * 10, properties={}, locks=None,
                   spot_instance=False, max_spot_price=1.6, volumes=[],
-@@ -66,6 +67,10 @@ class EC2LatentBuildSlave(AbstractLatentBuildSlave):
+@@ -72,6 +73,10 @@ class EC2LatentBuildSlave(AbstractLatentBuildSlave):
          AbstractLatentBuildSlave.__init__(
              self, name, password, max_builds, notify_on_missing,
              missing_timeout, build_wait_timeout, properties, locks)
@@ -39,7 +39,7 @@ index 622bcc973..154c06bd3 100644
          if not ((ami is not None) ^
                  (valid_ami_owners is not None or
                   valid_ami_location_regex is not None)):
-@@ -92,7 +97,7 @@ class EC2LatentBuildSlave(AbstractLatentBuildSlave):
+@@ -98,7 +103,7 @@ class EC2LatentBuildSlave(AbstractLatentBuildSlave):
          if keypair_name is None:
              keypair_name = 'latent_buildbot_slave'
              log.msg('Using default keypair name, since none is set')
@@ -47,8 +47,8 @@ index 622bcc973..154c06bd3 100644
 +        if security_name is None and not subnet_id:
              security_name = 'latent_buildbot_slave'
              log.msg('Using default keypair name, since none is set')
-         self.valid_ami_owners = valid_ami_owners
-@@ -181,23 +186,24 @@ class EC2LatentBuildSlave(AbstractLatentBuildSlave):
+         if spot_instance and price_multiplier is None and max_spot_price is None:
+@@ -191,23 +196,24 @@ class EC2LatentBuildSlave(AbstractLatentBuildSlave):
              self.conn.create_key_pair(keypair_name)
  
          # create security group
@@ -90,7 +90,7 @@ index 622bcc973..154c06bd3 100644
  
          # get the image
          if self.ami is not None:
-@@ -211,6 +217,9 @@ class EC2LatentBuildSlave(AbstractLatentBuildSlave):
+@@ -221,6 +227,9 @@ class EC2LatentBuildSlave(AbstractLatentBuildSlave):
          if elastic_ip is not None:
              elastic_ip = self.conn.get_all_addresses([elastic_ip])[0]
          self.elastic_ip = elastic_ip
@@ -100,7 +100,7 @@ index 622bcc973..154c06bd3 100644
          self.tags = tags
  
      def get_image(self):
-@@ -277,9 +286,10 @@ class EC2LatentBuildSlave(AbstractLatentBuildSlave):
+@@ -287,9 +296,10 @@ class EC2LatentBuildSlave(AbstractLatentBuildSlave):
      def _start_instance(self):
          image = self.get_image()
          reservation = image.run(
@@ -113,10 +113,10 @@ index 622bcc973..154c06bd3 100644
          self.instance = reservation.instances[0]
          instance_id, image_id, start_time = self._wait_for_instance(
              reservation)
-@@ -397,11 +407,12 @@ class EC2LatentBuildSlave(AbstractLatentBuildSlave):
-                     (self.__class__.__name__, self.slavename, target_price))
+@@ -442,11 +452,12 @@ class EC2LatentBuildSlave(AbstractLatentBuildSlave):
+                 (self.__class__.__name__, self.slavename, bid_price))
          reservations = self.conn.request_spot_instances(
-             target_price, self.ami, key_name=self.keypair_name,
+             bid_price, self.ami, key_name=self.keypair_name,
 -            security_groups=[
 -                self.security_name],
 +            security_groups=self.classic_security_groups,
@@ -133,10 +133,11 @@ diff --git a/master/buildbot/test/unit/test_buildslave_ec2.py b/master/buildbot/
 index f52fe7d61..b8874dd4f 100644
 --- a/master/buildbot/test/unit/test_buildslave_ec2.py
 +++ b/master/buildbot/test/unit/test_buildslave_ec2.py
-@@ -86,6 +86,52 @@ class TestEC2LatentBuildSlave(unittest.TestCase):
+@@ -85,6 +85,52 @@ class TestEC2LatentBuildSlave(unittest.TestCase):
+                                      )
          self.assertEqual(bs.tags, tags)
  
-     @mock_ec2
++    @mock_ec2
 +    def test_fail_mixing_classic_and_vpc_ec2_settings(self):
 +        c = self.botoSetup()
 +        amis = c.get_all_images()
@@ -182,12 +183,11 @@ index f52fe7d61..b8874dd4f 100644
 +        self.assertEqual(len(instances[0].groups), 1)
 +        self.assertEqual(instances[0].groups[0].id, sg.id)
 +
-+    @mock_ec2
+     @mock_ec2
      def test_start_instance(self):
          c = self.botoSetup()
-         amis = c.get_all_images()
 diff --git a/master/docs/manual/cfg-buildslaves.rst b/master/docs/manual/cfg-buildslaves.rst
-index d8ddd1884..99e23162d 100644
+index ef70c3fb2..cfc7dbc3d 100644
 --- a/master/docs/manual/cfg-buildslaves.rst
 +++ b/master/docs/manual/cfg-buildslaves.rst
 @@ -348,6 +348,27 @@ The ``missing_timeout`` and ``notify_on_missing`` specify how long to wait for a
@@ -219,5 +219,5 @@ index d8ddd1884..99e23162d 100644
  ##############
  
 -- 
-2.13.6
+2.14.3
 

--- a/master/patches/0016-Add-support-for-block-devices-to-EC2LatentBuildSlave.patch
+++ b/master/patches/0016-Add-support-for-block-devices-to-EC2LatentBuildSlave.patch
@@ -1,7 +1,7 @@
-From 9a6bd185a28c029f2141d2cff97a6329d6a1d6c4 Mon Sep 17 00:00:00 2001
+From ae680ca8b78c6fbc3fc7ed046f831bb54a922578 Mon Sep 17 00:00:00 2001
 From: Neal Gompa <ngompa@datto.com>
 Date: Tue, 3 Apr 2018 17:39:52 -0400
-Subject: [PATCH 09/18] Add support for block devices to EC2LatentBuildSlave
+Subject: [PATCH 16/18] Add support for block devices to EC2LatentBuildSlave
 
 Partially adapted from 8b67f91b50d72979ff620413dc4169d277b519df in buildbot 0.9.x,
 originally authored by Ryan Sydnor <ryan.t.sydnor@gmail.com>.
@@ -14,7 +14,7 @@ Signed-off-by: Neal Gompa <ngompa@datto.com>
  3 files changed, 87 insertions(+), 3 deletions(-)
 
 diff --git a/master/buildbot/buildslave/ec2.py b/master/buildbot/buildslave/ec2.py
-index 154c06bd3..bc7926547 100644
+index dd111e283..bbf5d4b88 100644
 --- a/master/buildbot/buildslave/ec2.py
 +++ b/master/buildbot/buildslave/ec2.py
 @@ -29,6 +29,8 @@ import boto
@@ -26,16 +26,16 @@ index 154c06bd3..bc7926547 100644
  from twisted.internet import defer
  from twisted.internet import threads
  from twisted.python import log
-@@ -62,7 +64,7 @@ class EC2LatentBuildSlave(AbstractLatentBuildSlave):
+@@ -68,7 +70,7 @@ class EC2LatentBuildSlave(AbstractLatentBuildSlave):
                   build_wait_timeout=60 * 10, properties={}, locks=None,
                   spot_instance=False, max_spot_price=1.6, volumes=[],
                   placement=None, price_multiplier=1.2, tags={},
--                 delete_vol_term=True):
-+                 delete_vol_term=True, block_device_map=None):
+-                 delete_vol_term=True, create_volumes=[]):
++                 delete_vol_term=True, create_volumes=[], block_device_map=None):
  
          AbstractLatentBuildSlave.__init__(
              self, name, password, max_builds, notify_on_missing,
-@@ -221,6 +223,21 @@ class EC2LatentBuildSlave(AbstractLatentBuildSlave):
+@@ -231,6 +233,21 @@ class EC2LatentBuildSlave(AbstractLatentBuildSlave):
          self.security_group_ids = security_group_ids
          self.classic_security_groups = [self.security_name] if self.security_name else None
          self.tags = tags
@@ -57,7 +57,7 @@ index 154c06bd3..bc7926547 100644
  
      def get_image(self):
          if self.image is not None:
-@@ -289,7 +306,8 @@ class EC2LatentBuildSlave(AbstractLatentBuildSlave):
+@@ -299,7 +316,8 @@ class EC2LatentBuildSlave(AbstractLatentBuildSlave):
              key_name=self.keypair_name, security_groups=self.classic_security_groups,
              instance_type=self.instance_type, user_data=self.user_data,
              placement=self.placement, subnet_id=self.subnet_id,
@@ -67,7 +67,7 @@ index 154c06bd3..bc7926547 100644
          self.instance = reservation.instances[0]
          instance_id, image_id, start_time = self._wait_for_instance(
              reservation)
-@@ -412,7 +430,8 @@ class EC2LatentBuildSlave(AbstractLatentBuildSlave):
+@@ -457,7 +475,8 @@ class EC2LatentBuildSlave(AbstractLatentBuildSlave):
              user_data=self.user_data,
              placement=self.placement,
              subnet_id=self.subnet_id,
@@ -81,10 +81,11 @@ diff --git a/master/buildbot/test/unit/test_buildslave_ec2.py b/master/buildbot/
 index b8874dd4f..09b073872 100644
 --- a/master/buildbot/test/unit/test_buildslave_ec2.py
 +++ b/master/buildbot/test/unit/test_buildslave_ec2.py
-@@ -151,6 +151,48 @@ class TestEC2LatentBuildSlave(unittest.TestCase):
+@@ -150,6 +150,48 @@ class TestEC2LatentBuildSlave(unittest.TestCase):
+         self.assertEqual(instances[0].id, instance_id)
          self.assertEqual(instances[0].tags, {})
  
-     @mock_ec2
++    @mock_ec2
 +    def test_start_instance_volumes(self):
 +        c = self.botoSetup()
 +        amis = c.get_all_images()
@@ -126,12 +127,11 @@ index b8874dd4f..09b073872 100644
 +            BlockDeviceType(volume_type='gp2', size=30, delete_on_termination=False),
 +            bs.block_device_map['/dev/xvdc'])
 +
-+    @mock_ec2
+     @mock_ec2
      def test_start_instance_tags(self):
          c = self.botoSetup()
-         amis = c.get_all_images()
 diff --git a/master/docs/manual/cfg-buildslaves.rst b/master/docs/manual/cfg-buildslaves.rst
-index 99e23162d..a468a73a7 100644
+index cfc7dbc3d..2ead58acc 100644
 --- a/master/docs/manual/cfg-buildslaves.rst
 +++ b/master/docs/manual/cfg-buildslaves.rst
 @@ -348,6 +348,29 @@ The ``missing_timeout`` and ``notify_on_missing`` specify how long to wait for a
@@ -165,5 +165,5 @@ index 99e23162d..a468a73a7 100644
  ##############
  
 -- 
-2.13.6
+2.14.3
 

--- a/master/patches/0017-Allow-control-over-environment-logging-MasterShellCo.patch
+++ b/master/patches/0017-Allow-control-over-environment-logging-MasterShellCo.patch
@@ -1,4 +1,4 @@
-From e6f3689acfe9cbc909fcc2b1880fbf724cdf3d0c Mon Sep 17 00:00:00 2001
+From 1ecdf1f980bd02bfda20ee127742164608fcd2a2 Mon Sep 17 00:00:00 2001
 From: Brian Behlendorf <behlendorf1@llnl.gov>
 Date: Tue, 17 Apr 2018 13:14:15 -0700
 Subject: [PATCH 17/18] Allow control over environment logging
@@ -40,5 +40,5 @@ index d2be1364e..2d980f155 100644
          # TODO add a timeout?
          self.process = reactor.spawnProcess(self.LocalPP(self), argv[0], argv,
 -- 
-2.13.6
+2.14.3
 

--- a/master/patches/0018-Better-handling-for-instance-termination.patch
+++ b/master/patches/0018-Better-handling-for-instance-termination.patch
@@ -1,4 +1,4 @@
-From 31937981f941b4f529fe113913f81eabc09bf72d Mon Sep 17 00:00:00 2001
+From 28598e70a562feb536e19c98af18269c8cc92786 Mon Sep 17 00:00:00 2001
 From: Brian Behlendorf <behlendorf1@llnl.gov>
 Date: Tue, 17 Apr 2018 13:16:16 -0700
 Subject: [PATCH 18/18] Better handling for instance termination
@@ -9,7 +9,7 @@ Signed-off-by: Brian Behlendorf <behlendorf1@llnl.gov>
  1 file changed, 10 insertions(+), 2 deletions(-)
 
 diff --git a/master/buildbot/buildslave/ec2.py b/master/buildbot/buildslave/ec2.py
-index b81c13754..1a2832711 100644
+index bbf5d4b88..8a576ee8a 100644
 --- a/master/buildbot/buildslave/ec2.py
 +++ b/master/buildbot/buildslave/ec2.py
 @@ -407,14 +407,22 @@ class EC2LatentBuildSlave(AbstractLatentBuildSlave):
@@ -38,5 +38,5 @@ index b81c13754..1a2832711 100644
                      (self.__class__.__name__, self.slavename, instance.id))
          duration = 0
 -- 
-2.13.6
+2.14.3
 

--- a/master/patches/README.md
+++ b/master/patches/README.md
@@ -13,9 +13,18 @@ Each patch is fully described in its commit comment.
 0004-Retry-on-EC2-NotFound-errors.patch
 0005-Soft-disconnect-when-build_wait_timeout-0.patch
 0006-Force-root-volumes-to-be-deleted-upon-termination-on.patch
-0007-Remove-default-values-for-keypair-and-security-names.patch
-0008-Add-VPC-support-to-EC2LatentBuildSlave.patch
-0009-Add-support-for-block-devices-to-EC2LatentBuildSlave.patch
+0007-Create-volumes.patch
+0008-Allow-slaves-to-substantiate-in-parallel.patch
+0009-Move-spot-price-historical-averaging-to-its-own-func.patch
+0010-Allow-independant-EC2-price_multiplier-or-max_spot_p.patch
+0011-Properly-handle-a-stale-broker-connection-on-ping.patch
+0012-Add-debug-logging.patch
+0013-Add-instance-id-to-build-properties.patch
+0014-Remove-default-values-for-keypair-and-security-names.patch
+0015-Add-VPC-support-to-EC2LatentBuildSlave.patch
+0016-Add-support-for-block-devices-to-EC2LatentBuildSlave.patch
+0017-Allow-control-over-environment-logging-MasterShellCo.patch
+0018-Better-handling-for-instance-termination.patch
 ```
 
 The patches cleanly apply on top of `9df5d7d2a4db811fde4780cc1555453ee0f12649`


### PR DESCRIPTION
Prior to the remaining production patches being committed in 3898450b79640d23df62cd5e2851c0f1e5a7232c, the `price_multiplier` setting did not work and caused it to crash on spinning up slaves. Now that the patches are published, the setting is confirmed to work again.

In addition, a trivial change to re-order the patches relatively based on when they were created to ensure that they can be applied incrementally is included along with updated patch documentation.

Signed-off-by: Neal Gompa <ngompa@datto.com>