### PR TITLE
Conditionally checkout and build the spl

### DIFF
--- a/master/github.py
+++ b/master/github.py
@@ -1,0 +1,266 @@
+# -*- python -*-
+# ex: set syntax=python:
+
+import logging
+import urllib2
+import json
+import string
+import re
+
+from password import *
+from buildbot.status.web.hooks.github import GitHubEventHandler
+from dateutil.parser import parse as dateparse
+from twisted.python import log
+
+def query_url(url, token=None):
+    log.msg("Making request to '%s'" % url)
+    request = urllib2.Request(url)
+    if token:
+        request.add_header("Authorization", "token %s" % token)
+    response = urllib2.urlopen(request)
+
+    return json.loads(response.read())
+
+#
+# Custom class to determine how to handle incoming Github changes.
+#
+class CustomGitHubEventHandler(GitHubEventHandler):
+    valid_props = [
+        ('^Build[-\s]linux:\s*(yes|no)\s*$', 'override-buildlinux'),
+        ('^Build[-\s]lustre:\s*(yes|no)\s*$', 'override-buildlustre'),
+        ('^Build[-\s]spl:\s*(yes|no)\s*$', 'override-buildspl'),
+        ('^Build[-\s]zfs:\s*(yes|no)\s*$', 'override-buildzfs'),
+        ('^Built[-\s]in:\s*(yes|no)\s*$', 'override-builtin'),
+        ('^Check[-\s]lint:\s*(yes|no)\s*$', 'override-checklint'),
+        ('^Configure[-|\s]lustre:(.*)$', 'override-configlustre'),
+        ('^Configure[-|\s]spl:(.*)$', 'override-configspl'),
+        ('^Configure[-|\s]zfs:(.*)$', 'override-configzfs'),
+        ('^Perf[-|\s]zts:\s*(yes|no)\s*$', 'override-perfzts'),
+        ('^Perf[-|\s]pts:\s*(yes|no)\s*$', 'override-perfpts'),
+    ]
+
+    def parse_comments(self, comments, default_category):
+        category = default_category
+
+        # Extract any overrides for builders for this commit
+        # Requires-builders: style build arch distro test perf none
+        category_pattern = '^Requires-builders:\s*([ ,a-zA-Z0-9]+)'
+        m = re.search(category_pattern, comments, re.I | re.M)
+        if m is not None:
+            category = m.group(1).lower();
+
+            # If Requires-builders contains 'none', then skip this commit
+            none_pattern = '.*none.*'
+            m = re.search(none_pattern, category, re.I | re.M)
+            if m is not None:
+                category = ""
+
+            # If Requires-builders contains 'all', then run all builders.
+            all_pattern = '.*all.*'
+            m = re.search(all_pattern, category, re.I | re.M)
+            if m is not None:
+                category = "style,build,test,perf,coverage,unstable"
+
+        return category
+
+    def handle_push(self, payload):
+        changes = []
+        refname = payload['ref']
+
+        log.msg("Processing GitHub Push `%s'" % refname)
+
+        # We only care about regular heads, i.e. branches
+        match = re.match(r"^refs\/heads\/(.+)$", refname)
+        if not match:
+            log.msg("Ignoring refname `%s': Not a branch" % refname)
+            return changes, 'git'
+
+        branch = match.group(1)
+        if payload.get('deleted'):
+            log.msg("Branch `%s' deleted, ignoring" % branch)
+            return changes, 'git'
+
+        for commit in payload['commits']:
+            if not commit.get('distinct', True):
+                log.msg('Commit `%s` is a non-distinct commit, ignoring...' %
+                        (commit['id'],))
+                continue
+
+            created_at = dateparse(commit['timestamp'])
+            comments = commit['message']
+
+            # Assemble the list of modified files.
+            files = []
+            for kind in ('added', 'modified', 'removed'):
+                files.extend(commit.get(kind, []))
+
+            # Extract if the commit message has property overrides
+            props = { }
+            for prop in CustomGitHubEventHandler.valid_props:
+                step_pattern = prop[0]
+                m = re.search(step_pattern, comments, re.I | re.M)
+                if m is not None:
+                    prop_name = prop[1]
+                    props[prop_name] = json.dumps(m.group(1).lower())
+
+            # Extract if the commit message has property overrides
+            category = self.parse_comments(comments,
+                "style,build,test,perf,coverage,unstable")
+
+            # Releases prior to 0.8.0 required an external spl build.
+            match = re.match(r".*-0.[0-7]-release", branch)
+            if not match:
+                props['buildspl'] = json.dumps("no")
+            else:
+                props['buildspl'] = json.dumps("yes")
+
+            # Run performance testing on pushes.
+            # ZTS performance run time tuning required (disabled).
+            props['perfpts'] = json.dumps("yes")
+            props['perfzts'] = json.dumps("no")
+
+            change = {
+                'revision' : commit['id'],
+                'when_timestamp': created_at,
+                'branch': branch,
+                'revlink' : commit['url'],
+                'repository': payload['repository']['url'],
+                'project' : payload['repository']['full_name'],
+                'properties' : props,
+                'category': category,
+                'author': "%s <%s>" % (commit['author']['name'],
+                                       commit['author']['email']),
+                'comments' : comments,
+                'files' : files,
+            }
+
+            if callable(self._codebase):
+                change['codebase'] = self._codebase(payload)
+            elif self._codebase is not None:
+                change['codebase'] = self._codebase
+
+            changes.append(change)
+
+        log.msg("Received %d changes pushed from github" % len(changes))
+
+        return changes, 'git'
+
+    def handle_pull_request(self, payload):
+        changes = []
+        number = payload['number']
+        refname = 'refs/pull/%d/head' % (number,)
+        commits_num = payload['pull_request']['commits']
+        commits_url = payload['pull_request']['commits_url']
+        created_at = dateparse(payload['pull_request']['created_at'])
+        commits_cur = 0
+
+        log.msg('Processing GitHub PR #%d' % number, logLevel=logging.DEBUG)
+
+        action = payload.get('action')
+        if action not in ('opened', 'reopened', 'synchronize'):
+            log.msg("GitHub PR #%d %s, ignoring" % (number, action))
+            return changes, 'git'
+
+        commits = query_url(commits_url, token=github_token)
+
+        # Extract any dependency information and translate to a standard form.
+        # Requires-spl: refs/pull/PR/head
+        spl_pull_request = None
+        spl_pattern = '^Requires-spl:\s*([a-zA-Z0-9_\-\:\/\+]+)'
+        for commit in commits:
+            comments = commit['commit']['message']
+            m = re.search(spl_pattern, comments, re.I | re.M)
+            if m is not None:
+                spl_pull_request = 'Requires-spl: %s' % m.group(1)
+                break
+
+        kernel_pull_request = None
+        kernel_pattern = '^Requires-kernel:\s*([a-zA-Z0-9_\-\:\/\+\.]+)'
+        for commit in commits:
+            comments = commit['commit']['message']
+            m = re.search(kernel_pattern, comments, re.I | re.M)
+            if m is not None:
+                kernel_pull_request = 'Requires-kernel: %s' % m.group(1)
+                break
+
+        for commit in commits:
+            commit = query_url(commit['url'], token=github_token)
+            commits_cur += 1
+            comments = commit['commit']['message'] + "\n\n"
+
+            # Assemble the list of modified files.
+            changed_files = []
+            for f in commit['files']:
+                changed_files.append(f['filename'])
+
+            # Extract if the commit message has property overrides
+            props = { }
+            for prop in CustomGitHubEventHandler.valid_props:
+                step_pattern = prop[0]
+                m = re.search(step_pattern, comments, re.I | re.M)
+                if m is not None:
+                    prop_name = prop[1]
+                    props[prop_name] = json.dumps(m.group(1).lower())
+
+            # Annotate the head commit to allow special handling.
+            if commit['sha'] == payload['pull_request']['head']['sha']:
+                category = "style,build,test,coverage"
+            else:
+                category = "style,build"
+
+            # Extract if the commit message has property overrides
+            category = self.parse_comments(comments, category)
+
+            # Annotate every commit with 'Requires-spl' when missing.
+            if spl_pull_request:
+                if re.search(spl_pattern, comments, re.I | re.M) is None:
+                    comments = comments + spl_pull_request + "\n"
+
+            if kernel_pull_request:
+                if re.search(kernel_pattern, comments, re.I | re.M) is None:
+                    comments = comments + kernel_pull_request + "\n"
+
+            comments = comments + "Pull-request: #%d part %d/%d\n" % (
+                number, commits_cur, commits_num)
+
+            branch = payload['pull_request']['base']['ref']
+            props['branch'] = json.dumps(branch)
+            props['pr_number'] = json.dumps(number)
+
+            # Releases prior to 0.8.0 required an external spl build.
+            match = re.match(r".*-0.[0-7]-release", branch)
+            if not match:
+                props['buildspl'] = json.dumps("no")
+            else:
+                props['buildspl'] = json.dumps("yes")
+
+            # Run performance testing on PRs.
+            props['perfpts'] = json.dumps("no")
+            props['perfzts'] = json.dumps("yes")
+
+            change = {
+                'revision' : commit['sha'],
+                'when_timestamp': created_at,
+                'branch': refname,
+                'revlink' : commit['html_url'],
+                'repository': payload['repository']['clone_url'],
+                'project' : payload['repository']['name'],
+                'properties' : props,
+                'category': category,
+                'author': "%s <%s>" % (commit['commit']['committer']['name'],
+                                       commit['commit']['committer']['email']),
+                'comments' : comments,
+                'files' : changed_files,
+            }
+
+            if callable(self._codebase):
+                change['codebase'] = self._codebase(payload)
+            elif self._codebase is not None:
+                change['codebase'] = self._codebase
+
+            changes.append(change)
+
+        log.msg("Received %d changes from GitHub Pull Request #%d" % (
+            len(changes), number))
+
+        return changes, 'git'

--- a/master/master.cfg
+++ b/master/master.cfg
@@ -4,13 +4,17 @@
 from buildbot.plugins import *
 from twisted.python import log
 from password import *
+from github import *
 from buildslaves import *
 from buildbot.buildslave import BuildSlave
 from buildbot.plugins import util
 from buildbot.schedulers.timed import Nightly
 
+import os.path
+import copy
+import re
+
 bb_slave_port = 9989
-bb_try_port = 8033
 bb_web_port = 8010
 bb_master = "build.zfsonlinux.org:9989"
 bb_url = "https://raw.githubusercontent.com/zfsonlinux/zfs-buildbot/master/scripts/"
@@ -66,15 +70,21 @@ from buildbot.status.results import SKIPPED
 
 def do_step_build(step, name):
     props = step.build.getProperties()
+
     override_name = 'override-' + name
     if props.hasProperty(override_name):
-        if props[override_name] == "yes":
+        m = re.match(r".*yes.*", props[override_name])
+        if m is not None:
             return True
         else:
             return False
 
-    if props.hasProperty(name) and props[name] == "yes":
-        return True
+    if props.hasProperty(name):
+        m = re.match(r".*yes.*", props[name])
+        if m is not None:
+            return True
+        else:
+            return False
     else:
         return False
 
@@ -91,21 +101,19 @@ def do_step_build_zfs(step):
     return do_step_build(step, 'buildzfs')
 
 def perform_spl_build(step):
-    return do_step_build(step, 'buildspl') and \
-        not do_step_build(step, 'builtin')
+    return do_step_build_spl(step) and not do_step_build(step, 'builtin')
 
 def perform_zfs_build(step):
-    return do_step_build(step, 'buildzfs') and \
-        not do_step_build(step, 'builtin')
+    return do_step_build_zfs(step) and not do_step_build(step, 'builtin')
 
 def do_step_check_lint(step):
     return do_step_build(step, 'checklint')
 
-def do_step_pts(step):
-    return do_step_build(step, 'runpts')
+def do_step_perf_pts(step):
+    return do_step_build(step, 'perfpts')
 
-def do_step_zts(step):
-    return do_step_build(step, 'runzts')
+def do_step_perf_zts(step):
+    return do_step_build(step, 'perfzts')
 
 def determine_prop(props, name, default):
     override_name = 'override-' + name
@@ -613,7 +621,7 @@ perf_factory.addStep(ShellCommand(
     logfiles={"deploy" : { "filename" : "deploy.log", "follow" : True }},
     decodeRC={0 : SUCCESS, 1 : FAILURE, 2 : WARNINGS, 3 : SKIPPED },
     timeout=5400, description=["pts"], descriptionDone=["pts"],
-    doStepIf = do_step_pts,
+    doStepIf = do_step_perf_pts,
     hideStepIf=lambda results, s: results==SKIPPED))
 perf_factory.addStep(ShellCommand(
     workdir="build/tests",
@@ -632,7 +640,7 @@ perf_factory.addStep(ShellCommand(
               "kmemleak" : { "filename" : "kmemleak.log", "follow" : False }},
     decodeRC={0 : SUCCESS, 1 : FAILURE, 2 : WARNINGS, 3 : SKIPPED },
     description=["zfstests"], descriptionDone=["zfstests"],
-    doStepIf = do_step_zts,
+    doStepIf = do_step_perf_zts,
     hideStepIf=lambda results, s: results==SKIPPED))
 perf_factory.addStep(DirectoryUpload(
     slavesrc="/var/lib/buildbot/.phoronix-test-suite/test-results",
@@ -912,7 +920,6 @@ perf_tags = [ "Performance" ]
 builder_default_properties = {
     "buildlinux":    "no",
     "buildlustre":   "no",
-    "buildspl":      "yes",
     "buildzfs":      "yes",
     "builtin":       "no",
     "configlustre":  "",
@@ -927,7 +934,6 @@ builder_default_properties = {
 builder_coverage_properties = {
     "buildlinux":    "no",
     "buildlustre":   "no",
-    "buildspl":      "yes",
     "buildzfs":      "yes",
     "builtin":       "no",
     "configlustre":  "",
@@ -942,7 +948,6 @@ builder_coverage_properties = {
 builder_lustre_properties = {
     "buildlinux":    "no",
     "buildlustre":   "yes",
-    "buildspl":      "yes",
     "buildzfs":      "yes",
     "builtin":       "no",
     "configlustre":  "--with-zfs --disable-ldiskfs",
@@ -957,7 +962,6 @@ builder_lustre_properties = {
 builder_dkms_properties = {
     "buildlinux":    "no",
     "buildlustre":   "no",
-    "buildspl":      "yes",
     "buildzfs":      "yes",
     "builtin":       "no",
     "configlustre":  "",
@@ -972,7 +976,6 @@ builder_dkms_properties = {
 builder_redhat_properties = {
     "buildlinux":    "no",
     "buildlustre":   "no",
-    "buildspl":      "yes",
     "buildzfs":      "yes",
     "builtin":       "no",
     "configlustre":  "",
@@ -987,7 +990,6 @@ builder_redhat_properties = {
 builder_nodebug_properties = {
     "buildlinux":    "no",
     "buildlustre":   "no",
-    "buildspl":      "yes",
     "buildzfs":      "yes",
     "builtin":       "no",
     "configlustre":  "",
@@ -1002,7 +1004,6 @@ builder_nodebug_properties = {
 builder_builtin_properties = {
     "buildlinux":    "yes",
     "buildlustre":   "no",
-    "buildspl":      "yes",
     "buildzfs":      "yes",
     "builtin":       "yes",
     "configlustre":  "",
@@ -1017,7 +1018,6 @@ builder_builtin_properties = {
 builder_style_properties = {
     "buildlinux":    "no",
     "buildlustre":   "no",
-    "buildspl":      "yes",
     "buildzfs":      "yes",
     "builtin":       "no",
     "configlustre":  "",
@@ -1032,7 +1032,6 @@ builder_style_properties = {
 builder_arch_properties = {
     "buildlinux":    "no",
     "buildlustre":   "no",
-    "buildspl":      "yes",
     "buildzfs":      "yes",
     "builtin":       "no",
     "configlustre":  "",
@@ -1047,7 +1046,6 @@ builder_arch_properties = {
 builder_perf_properties = {
     "buildlinux":    "no",
     "buildlustre":   "no",
-    "buildspl":      "yes",
     "buildzfs":      "yes",
     "builtin":       "no",
     "configlustre":  "",
@@ -1332,168 +1330,6 @@ c['builders'] = all_builders
 c['protocols'] = {'pb': {'port': bb_slave_port}}
 
 
-import logging
-import urllib2
-import json
-
-from buildbot.status.web.hooks.github import GitHubEventHandler
-from dateutil.parser import parse as dateparse
-from twisted.python import log
-
-def query_url(url, token=None):
-    log.msg("Making request to '%s'" % url)
-    request = urllib2.Request(url)
-    if token:
-        request.add_header("Authorization", "token %s" % token)
-    response = urllib2.urlopen(request)
-    return json.loads(response.read())
-
-def parse_link_header(link_header):
-    links = {}
-    prog = re.compile('^<([^>]*)>; rel="([^"]*)"$')
-    for s in link_header.split(", "):
-        m = prog.search(s)
-        if m:
-            links[m.group(2)] = m.group(1)
-        else:
-            raise RuntimeError("Could not parse '%s'" % s)
-    return links
-
-class CustomGitHubEventHandler(GitHubEventHandler):
-    valid_props = [
-        ('^Build[-\s]linux:\s*(yes|no)\s*$', 'override-buildlinux'),
-        ('^Build[-\s]lustre:\s*(yes|no)\s*$', 'override-buildlustre'),
-        ('^Build[-\s]spl:\s*(yes|no)\s*$', 'override-buildspl'),
-        ('^Build[-\s]zfs:\s*(yes|no)\s*$', 'override-buildzfs'),
-        ('^Built[-\s]in:\s*(yes|no)\s*$', 'override-builtin'),
-        ('^Check[-\s]lint:\s*(yes|no)\s*$', 'override-checklint'),
-        ('^Configure[-|\s]lustre:(.*)$', 'override-configlustre'),
-        ('^Configure[-|\s]spl:(.*)$', 'override-configspl'),
-        ('^Configure[-|\s]zfs:(.*)$', 'override-configzfs'),
-    ]
-
-    def handle_pull_request(self, payload):
-        changes = []
-        number = payload['number']
-        refname = 'refs/pull/%d/head' % (number,)
-        commits_num = payload['pull_request']['commits']
-        commits_url = payload['pull_request']['commits_url']
-        created_at = dateparse(payload['pull_request']['created_at'])
-        commits_cur = 0
-
-        log.msg('Processing GitHub PR #%d' % number, logLevel=logging.DEBUG)
-
-        action = payload.get('action')
-        if action not in ('opened', 'reopened', 'synchronize'):
-            log.msg("GitHub PR #%d %s, ignoring" % (number, action))
-            return changes, 'git'
-
-        commits = query_url(commits_url, token=github_token)
-
-        # Extract any dependency information and translate to a standard form.
-        # Requires-spl: refs/pull/PR/head
-        spl_pull_request = None
-        spl_pattern = '^Requires-spl:\s*([a-zA-Z0-9_\-\:\/\+]+)'
-        for commit in commits:
-            comments = commit['commit']['message']
-            m = re.search(spl_pattern, comments, re.I | re.M)
-            if m is not None:
-                spl_pull_request = 'Requires-spl: %s' % m.group(1)
-                break
-
-        kernel_pull_request = None
-        kernel_pattern = '^Requires-kernel:\s*([a-zA-Z0-9_\-\:\/\+\.]+)'
-        for commit in commits:
-            comments = commit['commit']['message']
-            m = re.search(kernel_pattern, comments, re.I | re.M)
-            if m is not None:
-                kernel_pull_request = 'Requires-kernel: %s' % m.group(1)
-                break
-
-        for commit in commits:
-            commit = query_url(commit['url'], token=github_token)
-            commits_cur += 1
-            comments = commit['commit']['message'] + "\n\n"
-
-            # Assemble the list of modified files.
-            changed_files = []
-            for f in commit['files']:
-                changed_files.append(f['filename'])
-
-            # Annotate the head commit to allow special handling.
-            if commit['sha'] == payload['pull_request']['head']['sha']:
-                category = "style,build,test,coverage"
-            else:
-                category = "style,build"
-
-            # Extract if the commit message has property overrides
-            properties = {}
-            for prop in CustomGitHubEventHandler.valid_props:
-                step_pattern = prop[0]
-                m = re.search(step_pattern, comments, re.I | re.M)
-                if m is not None:
-                    prop_name = prop[1]
-                    properties[prop_name] = m.group(1).lower()
-
-            # Extract any overrides for builders for this commit
-            # Requires-builders: style build arch distro test perf none
-            category_pattern = '^Requires-builders:\s*([ ,a-zA-Z0-9]+)'
-            m = re.search(category_pattern, comments, re.I | re.M)
-            if m is not None:
-                category = m.group(1).lower();
-
-                # If Requires-builders contains 'none', then skip this commit
-                none_pattern = '.*none.*'
-                m = re.search(none_pattern, category, re.I | re.M)
-                if m is not None:
-                    continue
-
-                # If Requires-builders contains 'all', then run all builders.
-                all_pattern = '.*all.*'
-                m = re.search(all_pattern, category, re.I | re.M)
-                if m is not None:
-                    category = "style,build,test,perf,coverage,unstable"
-
-            # Annotate every commit with 'Requires-spl' when missing.
-            if spl_pull_request:
-                if re.search(spl_pattern, comments, re.I | re.M) is None:
-                    comments = comments + spl_pull_request + "\n"
-
-            if kernel_pull_request:
-                if re.search(kernel_pattern, comments, re.I | re.M) is None:
-                    comments = comments + kernel_pull_request + "\n"
-
-            comments = comments + "Pull-request: #%d part %d/%d\n" % (
-                number, commits_cur, commits_num)
-
-            properties['base_branch'] = payload['pull_request']['base']['ref']
-            properties['pr_number'] = number
-
-            change = {
-                'revision' : commit['sha'],
-                'when_timestamp': created_at,
-                'branch': refname,
-                'revlink' : commit['html_url'],
-                'repository': payload['repository']['clone_url'],
-                'project' : payload['repository']['name'],
-                'properties' : properties,
-                'category': category,
-                'author': "%s <%s>" % (commit['commit']['committer']['name'],
-                                       commit['commit']['committer']['email']),
-                'comments' : comments,
-                'files' : changed_files,
-            }
-
-            if callable(self._codebase):
-                change['codebase'] = self._codebase(payload)
-            elif self._codebase is not None:
-                change['codebase'] = self._codebase
-
-            changes.append(change)
-
-        log.msg("Received %d changes from GitHub Pull Request #%d" % (
-            len(changes), number))
-        return changes, 'git'
 
 def codebaseGenerator(chdict):
     return all_repositories[chdict['repository']]
@@ -1504,12 +1340,9 @@ c['codebaseGenerator'] = codebaseGenerator
 
 # Configure the Schedulers, which decide how to react to incoming changes.
 
-from buildbot.schedulers.trysched import Try_Userpass
 from buildbot.schedulers.basic import SingleBranchScheduler
 from buildbot.changes.filter import ChangeFilter
 from buildbot.changes import filter
-import os.path
-import copy
 
 style_builders = [builder.name for builder in style_builders]
 distro_builders = [builder.name for builder in distro_builders]
@@ -1522,16 +1355,16 @@ coverage_builders = [builder.name for builder in coverage_builders]
 c['schedulers'] = []
 
 default_codebases = {
-    'linux' : {'repository': linux_repo, 'branch': 'master', 'revision': None},
-    'lustre': {'repository': lustre_repo, 'branch': 'b2_11', 'revision': None},
-    'spl'   : {'repository': spl_repo, 'branch': 'master', 'revision': None},
-    'zfs'   : {'repository': zfs_repo, 'branch': 'master', 'revision': None} }
+    'linux' : {'repository': linux_repo, 'branch': 'master'},
+    'lustre': {'repository': lustre_repo, 'branch': 'b2_11'},
+    'spl'   : {'repository': spl_repo, 'branch': 'master'},
+    'zfs'   : {'repository': zfs_repo, 'branch': 'master'} }
 
 release_7_codebases = {
-    'spl' :
-        {'repository': spl_repo, 'branch': 'spl-0.7-release', 'revision': None},
-    'zfs' :
-        {'repository': zfs_repo, 'branch': 'zfs-0.7-release', 'revision': None}}
+    'linux' : {'repository': linux_repo, 'branch': 'master'},
+    'lustre': {'repository': lustre_repo, 'branch': 'b2_10'},
+    'spl' : {'repository': spl_repo, 'branch': 'spl-0.7-release'},
+    'zfs' : {'repository': zfs_repo, 'branch': 'zfs-0.7-release'}}
 
 class CustomSingleBranchScheduler(SingleBranchScheduler):
     spl_pull_request = None
@@ -1553,8 +1386,8 @@ class CustomSingleBranchScheduler(SingleBranchScheduler):
         else:
             self.kernel_pull_request = None
 
-        if 'base_branch' in change.properties:
-            self.zfs_branch = change.properties['base_branch']
+        if 'branch' in change.properties:
+            self.zfs_branch = change.properties['branch']
         else:
             self.zfs_branch = change.branch
 
@@ -1609,73 +1442,52 @@ c['schedulers'].append(Nightly(
 #    branch=None,
 #    hour=3, minute=0,
 #    builderNames=perf_builders,
-#    properties={"runpts": "yes", "runzts": "no"},
+#    properties={"perfpts": "yes", "perfzts": "no"},
 #    codebases=default_codebases))
 
-# This scheduler is for pull requests.
+# These schedulers are for pull requests and branch pushes.
 c['schedulers'].append(CustomSingleBranchScheduler(
     name="pull-request-style-scheduler",
     builderNames=style_builders,
     codebases=default_codebases,
     change_filter=filter.ChangeFilter(category_re=".*style.*")))
 
-# This scheduler is for pull requests.
 c['schedulers'].append(CustomSingleBranchScheduler(
     name="pull-request-build-distro-scheduler",
     builderNames=distro_builders,
     codebases=default_codebases,
     change_filter=filter.ChangeFilter(category_re=".*(build|distro).*")))
 
-# This scheduler is for pull requests.
 c['schedulers'].append(CustomSingleBranchScheduler(
     name="pull-request-build-arch-scheduler",
     builderNames=arch_builders,
     codebases=default_codebases,
     change_filter=filter.ChangeFilter(category_re=".*(build|arch).*")))
 
-# This scheduler is for pull requests.
 c['schedulers'].append(CustomSingleBranchScheduler(
     name="pull-request-test-scheduler",
     builderNames=test_builders,
     codebases=default_codebases,
     change_filter=filter.ChangeFilter(category_re=".*test.*")))
 
-# This scheduler is for pull requests.
 c['schedulers'].append(CustomSingleBranchScheduler(
     name="pull-request-perf-scheduler",
     builderNames=perf_builders,
     codebases=default_codebases,
     change_filter=filter.ChangeFilter(category_re=".*perf.*")))
 
-# This scheduler is for pull requests.
 c['schedulers'].append(CustomSingleBranchScheduler(
     name="pull-request-unstable-scheduler",
     builderNames=unstable_builders,
     codebases=default_codebases,
     change_filter=filter.ChangeFilter(category_re=".*unstable.*")))
 
-# This scheduler is for pull requests.
 c['schedulers'].append(CustomSingleBranchScheduler(
     name="pull-request-coverage-scheduler",
     builderNames=coverage_builders,
     codebases=default_codebases,
     change_filter=filter.ChangeFilter(category_re=".*coverage.*")))
 
-# This scheduler is for pushes to branches.
-c['schedulers'].append(CustomSingleBranchScheduler(
-    name="branch-scheduler",
-    codebases=default_codebases,
-    builderNames=style_builders+distro_builders+arch_builders+
-        test_builders+unstable_builders+coverage_builders+perf_builders,
-    properties={"runpts": "yes", "runzts": "no"},
-    change_filter=filter.ChangeFilter(project_re=".*/zfs.*")))
-
-# This allows for 'buildbot try' users.
-c['schedulers'].append(Try_Userpass(
-    name="try-scheduler",
-    port=bb_try_port,
-    builderNames=style_builders+distro_builders+arch_builders+test_builders,
-    userpass=try_userpass))
 
 ####### STATUS TARGETS
 


### PR DESCRIPTION
Update the CustomGitHubEventHandler to conditionally checkout and
build the SPL when required.  This is currently possible using
the "buildspl" property, but that propery is set by the builder
and cannot by overidden by a change.

Therefore, the "buildspl" property has been switched to a "Change"
properly so it can be set correctly in CustomGitHubEventHandler.
The "buildspl" properly will be set to "yes" when building any
commit on the zfs-0.7-release branch.  Otherwise, it will be set
to "no" and the spl checkout and build will be skipped.

As part of this change the CustomGitHubEventHandler() was moved
in to its own file to simplify the master.cfg.  Some additional
minor cleanup was also included.