### PR TITLE
Debian should be able to print dmesg

### DIFF
--- a/scripts/bb-bootstrap.sh
+++ b/scripts/bb-bootstrap.sh
@@ -242,6 +242,11 @@ Debian*)
 
     # Standardize ephemeral storage so it's available under /mnt.
     sed -i.bak 's/nobootwait/nofail/' /etc/fstab
+
+    # Allow normal users to read dmesg, restricted by default.
+    mkdir -p /etc/sysctl.d/
+    echo "kernel.dmesg_restrict = 0" >> /etc/sysctl.d/10-local.conf
+    sysctl kernel.dmesg_restrict=0
     ;;
 
 Fedora*)


### PR DESCRIPTION
Debian workers currently have an issue where dmesg cannot be
printed by locals user by default. This change configures these
systems upon bootstrap, allowing these systems to collect this
log normally.

Signed-off-by: Tom Caputi <tcaputi@datto.com>