### PR TITLE
Drop match_version hack to get real tag information

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -171,16 +171,6 @@ def get_branch_or_pr(props):
         return 'artifacts/branch/none'
 
 #
-# XXX: Merging the independant SPL commit history in to the ZFS repository
-# has resulted in unadorned `git describe` printing a larger number of commits
-# past the last tag than an explicit `git describe --match=<tag>`.  In order
-# to ensure the commit-description property matches the resulting package
-# names the reference tag must be explicitly set.  The workaround can be
-# dropped once the next signed tag is made on the master branch.
-#
-match_version="zfs-0.7.0"
-
-#
 # Build factory - Build source in-tree
 #
 # Perform an in-tree build using the default options.  This is used to verify
@@ -199,7 +189,7 @@ style_factory.addStep(ShellCommand(
 style_factory.addStep(Git(repourl=zfs_repo, workdir="build/zfs",
     mode="full", method="clobber", codebase="zfs",
     logEnviron=False, lazylogfiles=True,
-    getDescription={ "match": match_version, "abbrev": 7 },
+    getDescription=True,
     description=["cloning"], descriptionDone=["cloned"]))
 style_factory.addStep(ShellCommand(
     workdir="build/zfs", env={'PATH' : bin_path,
@@ -259,7 +249,7 @@ build_factory.addStep(Git(repourl=spl_repo, workdir="build/spl",
 build_factory.addStep(Git(repourl=zfs_repo, workdir="build/zfs",
     mode="full", method="clobber", codebase="zfs",
     logEnviron=False, lazylogfiles=True,
-    getDescription={ "match": match_version, "abbrev": 7 },
+    getDescription=True,
     description=["cloning"], descriptionDone=["cloned"],
     doStepIf = do_step_build_zfs,
     hideStepIf=lambda results, s: results==SKIPPED))
@@ -376,7 +366,7 @@ test_factory.addStep(Git(repourl=spl_repo, workdir="build/spl",
 test_factory.addStep(Git(repourl=zfs_repo, workdir="build/zfs",
     mode="full", method="clobber", codebase="zfs",
     logEnviron=False, lazylogfiles=True,
-    getDescription={ "match": match_version, "abbrev": 7 },
+    getDescription=True,
     description=["cloning"], descriptionDone=["cloned"],
     doStepIf = do_step_build_zfs,
     hideStepIf=lambda results, s: results==SKIPPED))
@@ -637,7 +627,7 @@ perf_factory.addStep(Git(repourl=spl_repo, workdir="build/spl",
 perf_factory.addStep(Git(repourl=zfs_repo, workdir="build/zfs",
     mode="full", method="clobber", codebase="zfs",
     logEnviron=False, lazylogfiles=True,
-    getDescription={ "match": match_version, "abbrev": 7 },
+    getDescription=True,
     description=["cloning"], descriptionDone=["cloned"],
     doStepIf=do_step_build_zfs,
     hideStepIf=lambda results, s: results==SKIPPED))


### PR DESCRIPTION
With zfs-0.8.0-rc1 now tagged in master, this hack is no longer
needed in order to make Buildbot function properly.

Signed-off-by: Neal Gompa <ngompa@datto.com>