### PR TITLE
Move repository definitions to a separate file

### DIFF
--- a/master/master.cfg
+++ b/master/master.cfg
@@ -4,6 +4,7 @@
 from buildbot.plugins import *
 from twisted.python import log
 from password import *
+from repository import *
 from github import *
 from buildslaves import *
 from buildbot.buildslave import BuildSlave
@@ -20,23 +21,8 @@ bb_master = "build.zfsonlinux.org:9989"
 bb_url = "https://raw.githubusercontent.com/zfsonlinux/zfs-buildbot/master/scripts/"
 zol_url = "http://zfsonlinux.org"
 web_url = "http://build.zfsonlinux.org/"
-spl_repo = "https://github.com/zfsonlinux/spl.git"
-zfs_repo = "https://github.com/zfsonlinux/zfs.git"
-linux_repo = "https://github.com/torvalds/linux.git"
-lustre_repo = "git://git.hpdd.intel.com/fs/lustre-release.git"
 zfs_path = "/usr/libexec/zfs:/usr/share/zfs:/usr/lib/rpm/zfs:/usr/lib/zfs"
 bin_path = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
-
-all_repositories = {
-    "https://github.com/torvalds/linux" : 'linux',
-    "git://git.hpdd.intel.com/fs/lustre-release" : 'lustre',
-    "https://github.com/zfsonlinux/spl" : 'spl',
-    "https://github.com/zfsonlinux/zfs" : 'zfs',
-    "https://github.com/torvalds/linux.git" : 'linux',
-    "git://git.hpdd.intel.com/fs/lustre-release.git" : 'lustre',
-    "https://github.com/zfsonlinux/spl.git" : 'spl',
-    "https://github.com/zfsonlinux/zfs.git" : 'zfs',
-}
 
 c = BuildmasterConfig = {}
 

--- a/master/repository.py
+++ b/master/repository.py
@@ -1,0 +1,18 @@
+# -*- python -*-
+# ex: set syntax=python:
+
+spl_repo = "https://github.com/zfsonlinux/spl.git"
+zfs_repo = "https://github.com/zfsonlinux/zfs.git"
+linux_repo = "https://github.com/torvalds/linux.git"
+lustre_repo = "git://git.hpdd.intel.com/fs/lustre-release.git"
+
+all_repositories = {
+    "https://github.com/torvalds/linux" : 'linux',
+    "git://git.hpdd.intel.com/fs/lustre-release" : 'lustre',
+    "https://github.com/zfsonlinux/spl" : 'spl',
+    "https://github.com/zfsonlinux/zfs" : 'zfs',
+    "https://github.com/torvalds/linux.git" : 'linux',
+    "git://git.hpdd.intel.com/fs/lustre-release.git" : 'lustre',
+    "https://github.com/zfsonlinux/spl.git" : 'spl',
+    "https://github.com/zfsonlinux/zfs.git" : 'zfs',
+}


### PR DESCRIPTION
This centralizes the configuration of the repository sources in
a single file, similar to the passwords. In cases where other
Buildbot configuration modules need access to these settings, it
ensures we can avoid issues with circular imports.

Signed-off-by: Neal Gompa <ngompa@datto.com>