### PR TITLE
Update Amazon 2 AMI tests setup

### DIFF
--- a/scripts/bb-test-prepare.sh
+++ b/scripts/bb-test-prepare.sh
@@ -139,7 +139,7 @@ TEST_PREPARE_WATCHDOG=${TEST_PREPARE_WATCHDOG:-"Yes"}
 if echo "$TEST_PREPARE_WATCHDOG" | grep -Eiq "^yes$|^on$|^true$|^1$"; then
     case "$BB_NAME" in
     Amazon*)
-        sudo -E /etc/init.d/watchdog start
+        sudo -E systemctl start watchdog
         ;;
 
     CentOS*)
@@ -187,9 +187,8 @@ TEST_PREPARE_SHARES=${TEST_PREPARE_SHARES:-"Yes"}
 if echo "$TEST_PREPARE_SHARES" | grep -Eiq "^yes$|^on$|^true$|^1$"; then
     case "$BB_NAME" in
     Amazon*)
-        sudo -E /etc/init.d/rpcbind start
-        sudo -E /etc/init.d/nfs start
-        sudo -E /etc/init.d/smb start
+        sudo -E systemctl start nfs-server
+        sudo -E systemctl start smb
         ;;
 
     CentOS*)


### PR DESCRIPTION
The ZTS test case "zfs_share_005_pos" is failing on the Amazon 2 builder:

```
Test: /usr/share/zfs/zfs-tests/tests/functional/cli_root/zfs_share/zfs_share_005_pos (run as root) [00:00] [FAIL]
00:21:08.63 ASSERTION: Verify that NFS share options are propagated correctly.
00:21:08.65 SUCCESS: zfs set sharenfs=off testpool/testfs
00:21:08.71 SUCCESS: zfs set sharenfs=ro testpool/testfs
00:21:08.77 SUCCESS: zfs set sharenfs=rw testpool/testfs
00:21:08.82 SUCCESS: zfs set sharenfs=rw,insecure testpool/testfs
00:21:08.84 The 'insecure' option was not found in share output.
```

This is caused by the NFS server not being started. The latest Amazon 2 AMI introduced in 9118583b no longer uses SysV as the init system (http://build.zfsonlinux.org/builders/Amazon%202%20x86_64%20Release%20%28TEST%29/builds/3419/steps/shell_4/logs/stdio):

```
sudo: /etc/init.d/watchdog: command not found
sudo: /etc/init.d/rpcbind: command not found
sudo: /etc/init.d/nfs: command not found
sudo: /etc/init.d/smb: command not found
```

Update the "bb-test-prepare.sh" script to use systemd.

NOTE: i don't have access to Amazon, i hope i got the service names right.
