### PR TITLE
Add gdb and lcov packages for FreeBSD

### DIFF
--- a/scripts/bb-dependencies.sh
+++ b/scripts/bb-dependencies.sh
@@ -165,7 +165,9 @@ FreeBSD*)
         hs-ShellCheck \
         ksh93 \
         py36-flake8 \
-        samba410
+        samba410 \
+        gdb \
+        lcov
 
     sudo ln -sf /usr/local/bin/python3 /usr/local/bin/python
     ;;


### PR DESCRIPTION
gdb is needed by zloop.sh and lcov by codecov.