### PR TITLE
Add python2 and python3 packages for FreeBSD

### DIFF
--- a/scripts/bb-dependencies.sh
+++ b/scripts/bb-dependencies.sh
@@ -165,6 +165,8 @@ FreeBSD*)
         hs-ShellCheck \
         ksh93 \
         py36-flake8 \
+        python2 \
+        python3 \
         samba410 \
         gdb \
         lcov


### PR DESCRIPTION
The FreeBSD AMIs have python36 installed already, but that only gives
us /usr/local/bin/python3.6, while we also need the python3 link.

We need python2 as well in some places.

Signed-off-by: Ryan Moeller <ryan@ixsystems.com>