### PR TITLE
FreeBSD zfs-tests.sh debugging

### DIFF
--- a/scripts/bb-bootstrap.sh
+++ b/scripts/bb-bootstrap.sh
@@ -331,6 +331,7 @@ FreeBSD*)
     pip-2.7 --quiet install buildbot-slave
     BUILDSLAVE="/usr/local/bin/buildslave"
 
+    sed -i '' -e '/periodic/d' /etc/crontab
     pw useradd buildbot
     echo "buildbot ALL=(ALL) NOPASSWD: ALL" \
         >/usr/local/etc/sudoers.d/buildbot

--- a/scripts/bb-dependencies.sh
+++ b/scripts/bb-dependencies.sh
@@ -136,13 +136,14 @@ Fedora*)
     ;;
 
 FreeBSD*)
-    # XXX: Wait for the pkg db to be unlocked.
-    while sudo ps axww | fgrep pkg | fgrep -v fgrep; do
-        sleep 1
-    done
+    pkg_pid=$(pgrep pkg 2>/dev/null)
+    if [ -n "${pkg_pid}" ]; then
+        echo "Waiting for other pkg install to finish..."
+        pwait ${pkg_pid}
+    fi
 
     # Always test with the latest packages on FreeBSD.
-    sudo -E pkg upgrade -y
+    sudo -E pkg upgrade -y --no-repo-update
 
     # Kernel source
     (

--- a/scripts/bb-dependencies.sh
+++ b/scripts/bb-dependencies.sh
@@ -137,7 +137,7 @@ Fedora*)
 
 FreeBSD*)
     # Always test with the latest packages on FreeBSD.
-    sudo -E pkg upgrade -y --no-repo-update
+    sudo -E pkg upgrade -y
 
     # Kernel source
     (

--- a/scripts/bb-dependencies.sh
+++ b/scripts/bb-dependencies.sh
@@ -136,6 +136,11 @@ Fedora*)
     ;;
 
 FreeBSD*)
+    # XXX: Wait for the pkg db to be unlocked.
+    while sudo ps axww | fgrep pkg | fgrep -v fgrep; do
+        sleep 1
+    done
+
     # Always test with the latest packages on FreeBSD.
     sudo -E pkg upgrade -y
 
@@ -162,16 +167,13 @@ FreeBSD*)
     sudo -E pkg install -y --no-repo-update \
         base64 \
         fio \
-        hs-ShellCheck \
         ksh93 \
-        py36-flake8 \
+        python \
         python2 \
         python3 \
         samba410 \
         gdb \
         lcov
-
-    sudo ln -sf /usr/local/bin/python3 /usr/local/bin/python
     ;;
 
 RHEL*)

--- a/scripts/bb-test-zfstests.sh
+++ b/scripts/bb-test-zfstests.sh
@@ -147,8 +147,6 @@ fi
 ln -s /var/tmp/test_results/current/log $FULL_LOG
 
 set -x
-env
-which $ZFS_TESTS_SH
 $ZFS_TESTS_SH $TEST_ZFSTESTS_OPTIONS \
     ${TEST_ZFSTESTS_RUNFILE:+-r $TEST_ZFSTESTS_RUNFILE} \
     -d $TEST_ZFSTESTS_DIR \

--- a/scripts/bb-test-zfstests.sh
+++ b/scripts/bb-test-zfstests.sh
@@ -93,7 +93,7 @@ PERF_FS_OPTS=${TEST_ZFSTESTS_PERF_FS_OPTS:-"$DEFAULT_ZFSTESTS_PERF_FS_OPTS"}
 set +x
 
 if ! test -e /sys/module/zfs; then
-    sudo -E $ZFS_SH
+    sudo -E $ZFS_SH || echo "zfs.sh exited $?"
 fi
 
 # Performance profiling disabled by default due to size of profiling data.
@@ -147,6 +147,8 @@ fi
 ln -s /var/tmp/test_results/current/log $FULL_LOG
 
 set -x
+env
+which $ZFS_TESTS_SH
 $ZFS_TESTS_SH $TEST_ZFSTESTS_OPTIONS \
     ${TEST_ZFSTESTS_RUNFILE:+-r $TEST_ZFSTESTS_RUNFILE} \
     -d $TEST_ZFSTESTS_DIR \

--- a/scripts/bb-test-ztest.sh
+++ b/scripts/bb-test-ztest.sh
@@ -6,6 +6,9 @@ fi
 
 if test -f ./TEST; then
     . ./TEST
+    set -x
+    cat ./TEST
+    set +x
 else
     echo "Missing $PWD/TEST configuration file"
     exit 1


### PR DESCRIPTION
A few temporary changes in hopes of getting to the bottom of why zfs-tests.sh isn't running on FreeBSD.
Also trying to figure out what is interfering with pkg update.

Since it's only changing scripts there is no buildbot reload necessary and we can just retry an existing job to run it.