### PR TITLE
Fix several problems with the FreeBSD CI

### DIFF
--- a/scripts/bb-dependencies.sh
+++ b/scripts/bb-dependencies.sh
@@ -136,6 +136,12 @@ Fedora*)
     ;;
 
 FreeBSD*)
+    pkg_pid=$(pgrep pkg 2>/dev/null)
+    if [ -n "${pkg_pid}" ]; then
+        echo "Waiting for other pkg install to finish..."
+        pwait ${pkg_pid}
+    fi
+
     # Always test with the latest packages on FreeBSD.
     sudo -E pkg upgrade -y --no-repo-update
 

--- a/scripts/bb-dependencies.sh
+++ b/scripts/bb-dependencies.sh
@@ -169,12 +169,11 @@ FreeBSD*)
         base64 \
         fio \
         ksh93 \
+        python \
         python3 \
         samba410 \
         gdb \
         lcov
-
-    sudo ln -sf /usr/local/bin/python3 /usr/local/bin/python
     ;;
 
 RHEL*)

--- a/scripts/bb-dependencies.sh
+++ b/scripts/bb-dependencies.sh
@@ -168,10 +168,7 @@ FreeBSD*)
     sudo -E pkg install -y --no-repo-update \
         base64 \
         fio \
-        hs-ShellCheck \
         ksh93 \
-        py36-flake8 \
-        python2 \
         python3 \
         samba410 \
         gdb \

--- a/scripts/bb-test-cleanup.sh
+++ b/scripts/bb-test-cleanup.sh
@@ -11,17 +11,9 @@ else
     exit 1
 fi
 
-case "$BB_NAME" in
-FreeBSD*)
-    READLINK="readlink"
-    ;;
-Amazon*|CentOS*|Debian*|Fedora*|RHEL*|SUSE*|Ubuntu*)
-    READLINK="readlink -f"
-    ;;
-esac
-WORKDIR=$($READLINK .)
+WORKDIR=$(readlink -f .)
 GCOV_KERNEL="/sys/kernel/debug/gcov"
-ZFS_BUILD=$($READLINK ../zfs)
+ZFS_BUILD=$(readlink -f ../zfs)
 
 if $(sudo -E test ! -e "$GCOV_KERNEL"); then
     echo "Kernel Gcov disabled.  Skipping test cleanup."

--- a/scripts/bb-test-prepare.sh
+++ b/scripts/bb-test-prepare.sh
@@ -10,16 +10,8 @@ if echo "$TEST_PREPARE_SKIP" | grep -Eiq "^yes$|^on$|^true$|^1$"; then
     exit 3
 fi
 
-case "$BB_NAME" in
-FreeBSD*)
-    READLINK="readlink"
-    ;;
-Amazon*|CentOS*|Debian*|Fedora*|RHEL*|SUSE*|Ubuntu*)
-    READLINK="readlink -f"
-    ;;
-esac
-SPL_BUILD_DIR=$($READLINK ../spl)
-ZFS_BUILD_DIR=$($READLINK ../zfs)
+SPL_BUILD_DIR=$(readlink -f ../spl)
+ZFS_BUILD_DIR=$(readlink -f ../zfs)
 TEST_DIR="$PWD"
 TEST_FILE="${TEST_DIR}/TEST"
 


### PR DESCRIPTION
* Wait for the firstboot `pkg install awscli` as an extra safety measure on top of `--no-repo-update`
* Update the list of packages required as test dependencies
* Fix TEST_* variables in commit messages being lost