### PR TITLE
Mount fdescfs in FreeBSD bootstrap

### DIFF
--- a/scripts/bb-bootstrap.sh
+++ b/scripts/bb-bootstrap.sh
@@ -334,6 +334,9 @@ FreeBSD*)
     pw useradd buildbot
     echo "buildbot ALL=(ALL) NOPASSWD: ALL" \
         >/usr/local/etc/sudoers.d/buildbot
+
+    echo "fdescfs /dev/fd fdescfs rw 0 0" >> /etc/fstab
+    mount -a -t fdescfs
     ;;
 
 RHEL*)


### PR DESCRIPTION
Some tests use process substition, which requires fdescfs to be mounted at /dev/fd.

Signed-off-by: Ryan Moeller <ryan@iXsystems.com>